### PR TITLE
pin tf and lightgbm versions, fix some doc, remove unused constants

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -7,21 +7,6 @@
 from enum import Enum
 
 
-class BackCompat(object):
-    """Provide constants necessary for supporting old versions of our product."""
-
-    FEATURE_NAMES = 'feature_names'
-    NAME = 'name'
-    OLD_NAME = 'old_name'
-    OVERALL_FEATURE_ORDER = 'overall_feature_order'
-    OVERALL_IMPORTANCE_ORDER = 'overall_importance_order'
-    OVERALL_SUMMARY = 'overall_summary'
-    PER_CLASS_FEATURE_ORDER = 'per_class_feature_order'
-    PER_CLASS_IMPORTANCE_ORDER = 'per_class_importance_order'
-    PER_CLASS_SUMMARY = 'per_class_summary'
-    SHAP_VALUES = 'shap_values'
-
-
 class ExplanationParams(object):
     """Provide constants for explanation parameters."""
 
@@ -97,14 +82,6 @@ class ExplainType(object):
     SHAP_TREE = 'shap_tree'
     SHAP_LINEAR = 'shap_linear'
     TABULAR = 'tabular'
-
-
-class IO(object):
-    """Provide file input and output related constants."""
-
-    JSON = 'json'
-    PICKLE = 'pickle'
-    UTF8 = 'utf-8'
 
 
 class ExplainParams(object):

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -55,7 +55,7 @@ class MimicExplainer(BlackBoxExplainer):
         scipy.sparse.csr_matrix
     :param explainable_model: The uninitialized surrogate model used to explain the black box model.
         Also known as the student model.
-    :type explainable_model: azureml.explain.model.mimic.models.BaseExplainableModel
+    :type explainable_model: interpret_community.mimic.models.BaseExplainableModel
     :param explainable_model_args: An optional map of arguments to pass to the explainable model
         for initialization.
     :type explainable_model_args: dict
@@ -115,7 +115,7 @@ class MimicExplainer(BlackBoxExplainer):
         are specified, we approximate the feature importance values as probabilities instead
         of using the default values. If teacher probability is specified, we use the probabilities
         from the teacher model as opposed to the surrogate model.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param categorical_features: Categorical feature names or indexes.
         If names are passed, they will be converted into indexes first.
     :type categorical_features: Union[list[str], list[int]]
@@ -200,7 +200,7 @@ class MimicExplainer(BlackBoxExplainer):
             are specified, we approximate the feature importance values as probabilities instead
             of using the default values. If teacher probability is specified, we use the probabilities
             from the teacher model as opposed to the surrogate model.
-        :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+        :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param categorical_features: Categorical feature names or indexes.
             If names are passed, they will be converted into indexes first.
         :type categorical_features: Union[list[str], list[int]]
@@ -504,7 +504,7 @@ class MimicExplainer(BlackBoxExplainer):
         :param properties: A serialized dictionary representation of the mimic explainer.
         :type properties: dict
         :return: The deserialized MimicExplainer.
-        :rtype: azureml.explain.model.mimic.MimicExplainer
+        :rtype: interpret_community.mimic.MimicExplainer
         """
         # create the MimicExplainer without any properties using the __new__ function, similar to pickle
         mimic = MimicExplainer.__new__(MimicExplainer)

--- a/python/interpret_community/mimic/models/lightgbm_model.py
+++ b/python/interpret_community/mimic/models/lightgbm_model.py
@@ -47,7 +47,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
         'probability' is specified, then we approximately scale the raw log-odds values from the
         TreeExplainer to probabilities.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param classification: Indicates if this is a classification or regression explanation.
     :type classification: bool
     """
@@ -66,7 +66,7 @@ class LGBMExplainableModel(BaseExplainableModel):
             Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
             'probability' is specified, then we approximately scale the raw log-odds values from the
             TreeExplainer to probabilities.
-        :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+        :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param classification: Indicates if this is a classification or regression explanation.
         :type classification: bool
         """
@@ -242,7 +242,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         :param properties: A serialized dictionary representation of the LGBMExplainableModel.
         :type properties: dict
         :return: The deserialized LGBMExplainableModel.
-        :rtype: azureml.explain.model.mimic.models.LGBMExplainableModel
+        :rtype: interpret_community.mimic.models.LGBMExplainableModel
         """
         # create the LGBMExplainableModel without any properties using the __new__ function, similar to pickle
         lightgbm = LGBMExplainableModel.__new__(LGBMExplainableModel)

--- a/python/interpret_community/mimic/models/tree_model.py
+++ b/python/interpret_community/mimic/models/tree_model.py
@@ -34,7 +34,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
         'probability' is specified, then we approximately scale the raw log-odds values from the
         TreeExplainer to probabilities.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param classification: Indicates if this is a classification or regression explanation.
     :type classification: bool
     """
@@ -51,7 +51,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
             Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
             'probability' is specified, then we approximately scale the raw log-odds values from the
             TreeExplainer to probabilities.
-        :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+        :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param classification: Indicates if this is a classification or regression explanation.
         :type classification: bool
         """

--- a/python/interpret_community/mimic/models/tree_model_utils.py
+++ b/python/interpret_community/mimic/models/tree_model_utils.py
@@ -24,7 +24,7 @@ def _explain_local_tree_surrogate(tree_model, evaluation_examples, tree_explaine
         Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
         'probability' is specified, then we approximately scale the raw log-odds values from the
         TreeExplainer to probabilities.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param classification: Indicates if this is a classification or regression explanation.
     :type classification: bool
     :param probabilities: If output_type is probability, can specify the teacher model's
@@ -76,7 +76,7 @@ def _expected_values_tree_surrogate(tree_model, tree_explainer, shap_values_outp
         Currently only types 'default', 'probability' and 'teacher_probability' are supported.  If
         'probability' is specified, then we approximately scale the raw log-odds values from the
         TreeExplainer to probabilities.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param classification: Indicates if this is a classification or regression explanation.
     :type classification: bool
     :param multiclass: True if the tree_model is a multiclass model.

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -49,7 +49,7 @@ class TreeExplainer(PureStructuredModelExplainer):
         Currently only types 'default' and 'probability' are supported.  If 'probability'
         is specified, then we approximately scale the raw log-odds values from the TreeExplainer
         to probabilities.
-    :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+    :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
         The format for list of transformations is same as the one here:
@@ -107,7 +107,7 @@ class TreeExplainer(PureStructuredModelExplainer):
             Currently only types 'default' and 'probability' are supported.  If 'probability'
             is specified, then we approximately scale the raw log-odds values from the TreeExplainer
             to probabilities.
-        :type shap_values_output: azureml.explain.model.common.constants.ShapValuesOutput
+        :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation. The
         format for list of transformations is same as the one here:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 xmlrunner
-tensorflow
+tensorflow<2.0.0
 numpy
 pandas
 sklearn_pandas
 hdbscan
-lightgbm
+lightgbm<2.3.0
 xgboost
 prompt-toolkit>=2.0.0
 pytest


### PR DESCRIPTION
- pin tf and lightgbm versions to fix the failing build after new versions released
- fix some doc that was referencing azure
- remove unused constants