### PR TITLE
fix lightgbm serialization in v2.3.0

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -243,6 +243,7 @@ class LightGBMSerializationConstants(object):
     MODEL_STR = 'model_str'
     MULTICLASS = 'multiclass'
     TREE_EXPLAINER = '_tree_explainer'
+    OBJECTIVE = 'objective'
 
     enum_properties = ['_shap_values_output']
     nonify_properties = [LOGGER, TREE_EXPLAINER]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 pandas
 sklearn_pandas
 hdbscan
-lightgbm<2.3.0
+lightgbm
 xgboost
 prompt-toolkit>=2.0.0
 pytest


### PR DESCRIPTION
fix lightgbm serialization in v2.3.0
the lightgbm update broke the custom serialization logic we have for automl and our tests
the model string is now a top-level param

