### PR TITLE
add infrastructure to create a logging file on import if an env variable is specified

### DIFF
--- a/python/interpret_community/__init__.py
+++ b/python/interpret_community/__init__.py
@@ -11,3 +11,12 @@ confidence in the model.
 from .tabular_explainer import TabularExplainer
 
 __all__ = ["TabularExplainer"]
+
+# Setup logging infrustructure
+import logging
+import os
+# Only log to disk if environment variable specified
+interpretc_logs = os.environ.get('INTERPRETC_LOGS')
+if interpretc_logs is not None:
+    logging.basicConfig(filename=interpretc_logs, level=logging.INFO)
+    logging.info('Initializing logging file for interpret-community')


### PR DESCRIPTION
add infrastructure to create a logging file on import if an env variable is specified
If the 'INTERPRETC_LOGS' environment value is specified, we log any logging.info statements to the specified location on disk