### PR TITLE
fix indexes with pandas

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -180,9 +180,11 @@ class MimicSerializationConstants(object):
     MODEL = 'model'
     ORIGINAL_EVAL_EXAMPLES = '_original_eval_examples'
     PREDICT_PROBA_FLAG = 'predict_proba_flag'
+    TIMESTAMP_FEATURIZER = '_timestamp_featurizer'
 
     enum_properties = ['_shap_values_output']
-    nonify_properties = ['_logger', 'model', 'function', 'initialization_examples', '_original_eval_examples']
+    nonify_properties = ['_logger', 'model', 'function', 'initialization_examples',
+                         '_original_eval_examples', '_timestamp_featurizer']
     save_properties = ['surrogate_model']
 
 

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -237,7 +237,6 @@ class TestMimicExplainer(object):
         for verifier in verify_mimic:
             verifier.verify_explain_model_categorical(pass_categoricals=True)
 
-    @pytest.mark.skip(reason='Pandas indexes not supported yet')
     @pytest.mark.parametrize("sample_cnt_per_grain,grains_dict", [
         (240, {}),
         (20, {'fruit': ['apple', 'grape'], 'store': [100, 200, 50]})])
@@ -245,9 +244,11 @@ class TestMimicExplainer(object):
         X, _ = create_timeseries_data(sample_cnt_per_grain, 'time', 'y', grains_dict)
         model = DataFrameTestModel(X.copy())
         model = Pipeline([('test', model)])
-        features = list(X.columns)
+        features = list(X.columns.values) + list(X.index.names)
         model_task = ModelTask.Unknown
-        kwargs = {'explainable_model_args': {'n_jobs': 1}, 'augment_data': False}
+        kwargs = {'explainable_model_args': {'n_jobs': 1}, 'augment_data': False, 'reset_index': True}
+        if grains_dict:
+            kwargs['categorical_features'] = ['fruit']
         mimic_explainer(model, X, LGBMExplainableModel, features=features, model_task=model_task, **kwargs)
 
     def test_explain_model_imbalanced_classes(self, mimic_explainer):

--- a/test/test_timestamp_featurizer.py
+++ b/test/test_timestamp_featurizer.py
@@ -1,0 +1,51 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import pytest
+import logging
+
+import pandas as pd
+from pandas.api.types import is_datetime64_any_dtype as is_datetime
+
+from interpret_community.dataset.dataset_wrapper import CustomTimestampFeaturizer
+from constants import DatasetConstants, owner_email_tools_and_ux
+from common_utils import create_timeseries_data
+
+test_logger = logging.getLogger(__name__)
+
+
+@pytest.mark.owner(email=owner_email_tools_and_ux)
+@pytest.mark.usefixtures('clean_dir')
+class TestTimestampFeaturizer(object):
+
+    def test_working(self):
+        assert True
+
+    def test_no_timestamps(self, iris):
+        # create pandas dataframes without any timestamps
+        x_train = pd.DataFrame(data=iris[DatasetConstants.X_TRAIN], columns=iris[DatasetConstants.FEATURES])
+        x_test = pd.DataFrame(data=iris[DatasetConstants.X_TEST], columns=iris[DatasetConstants.FEATURES])
+        featurizer = CustomTimestampFeaturizer(iris[DatasetConstants.FEATURES]).fit(x_train)
+        result = featurizer.transform(x_test)
+        # Assert result is same as before, pandas dataframe
+        assert(isinstance(result, pd.DataFrame))
+        # Assert the result is the same as the original passed in data (no featurization was done)
+        assert(result.equals(x_test))
+
+    @pytest.mark.parametrize("sample_cnt_per_grain,grains_dict", [
+        (240, {}),
+        (20, {'fruit': ['apple', 'grape'], 'store': [100, 200, 50]})])
+    def test_timestamp_featurization(self, sample_cnt_per_grain, grains_dict):
+        # create timeseries data
+        X, _ = create_timeseries_data(sample_cnt_per_grain, 'time', 'y', grains_dict)
+        original_cols = list(X.columns.values)
+        # featurize and validate the timestamp column
+        featurizer = CustomTimestampFeaturizer(original_cols).fit(X)
+        result = featurizer.transform(X)
+        # Form a temporary dataframe for validation
+        tmp_result = pd.DataFrame(result)
+        # Assert there are no timestamp columns
+        assert([column for column in tmp_result.columns if is_datetime(tmp_result[column])] == [])
+        # Assert we have the expected number of columns - 1 time columns * 6 featurized plus original
+        assert(result.shape[1] == len(original_cols) + 6)


### PR DESCRIPTION
fix indexes with pandas

- add pandas indexes support, specifically for explaining timeseries models
- add datetime featurization
- fix bug in string indexing with one-hot-encoding for models that can't handle categoricals natively