### PR TITLE
switch to use rank from downloads for num_classes

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1297,7 +1297,7 @@ def _create_global_explanation_kwargs(local_explanation=None, expected_values=No
     # but currently in other cases when we aggregate local explanations we get per class
     if classification:
         if local_explanation is not None or ExplainParams.PER_CLASS_VALUES in kwargs:
-            kwargs[ExplainParams.NUM_CLASSES] = len(kwargs[ExplainParams.PER_CLASS_VALUES])
+            kwargs[ExplainParams.NUM_CLASSES] = len(kwargs[ExplainParams.PER_CLASS_RANK])
             mixins.append(PerClassMixin)
         else:
             mixins.append(ClassesMixin)


### PR DESCRIPTION
Fixes a bug that was showing up in azureml-interpret. Download only produces per_class_rank, so we need to use that.