### PR TITLE
Adding eval_data_viz to Explanation

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -48,6 +48,7 @@ class ExplainParams(object):
     CLASSES = 'classes'
     CLASSIFICATION = 'classification'
     EVAL_DATA = 'eval_data'
+    EVAL_DATA_VIZ = 'eval_data_viz'
     EVAL_Y_PRED = 'eval_y_predicted'
     EVAL_Y_PRED_PROBA = 'eval_y_predicted_proba'
     EXPECTED_VALUES = 'expected_values'
@@ -97,6 +98,7 @@ class Defaults(object):
     # See this github repo for more details: https://github.com/scikit-learn-contrib/hdbscan
     HDBSCAN = 'hdbscan'
     MAX_DIM = 50
+    EVAL_DATA_VIZ_LIMIT = 5000
 
 
 class Attributes(object):
@@ -251,3 +253,6 @@ class SHAPDefaults(object):
     """Provide constants for default values to shap."""
 
     INDEPENDENT = 'independent'
+
+
+

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1248,6 +1248,15 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_ID] = model_id
     DynamicLocalExplanation = type(Dynamic.LOCAL_EXPLANATION, tuple(mixins), {})
     local_explanation = DynamicLocalExplanation(explanation_id=exp_id, **kwargs)
+
+    if hasattr(local_explanation, ExplainParams.EVAL_DATA):
+        if (len(local_explanation.eval_data) > Defaults.EVAL_DATA_VIZ_LIMIT):
+            random_indices = sorted(np.random.choice(local_explanation.eval_data.shape[0], Defaults.EVAL_DATA_VIZ_LIMIT, replace=False))
+            eval_data_for_viz = local_explanation.eval_data[random_indices]
+        else:
+            eval_data_for_viz = local_explanation.eval_data
+        setattr(local_explanation, ExplainParams.EVAL_DATA_VIZ, eval_data_for_viz)
+
     return local_explanation
 
 
@@ -1348,6 +1357,8 @@ def _create_global_explanation(local_explanation=None, expected_values=None,
                                                        classification, explanation_id, **kwargs)
     DynamicGlobalExplanation = type(Dynamic.GLOBAL_EXPLANATION, tuple(mixins), {})
     global_explanation = DynamicGlobalExplanation(**kwargs)
+    if hasattr(local_explanation, ExplainParams.EVAL_DATA_VIZ):
+        setattr(global_explanation, ExplainParams.EVAL_DATA_VIZ, getattr(local_explanation, ExplainParams.EVAL_DATA_VIZ))
     return global_explanation
 
 

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1248,7 +1248,6 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_ID] = model_id
     DynamicLocalExplanation = type(Dynamic.LOCAL_EXPLANATION, tuple(mixins), {})
     local_explanation = DynamicLocalExplanation(explanation_id=exp_id, **kwargs)
-
     if hasattr(local_explanation, ExplainParams.EVAL_DATA):
         if (len(local_explanation.eval_data) > Defaults.EVAL_DATA_VIZ_LIMIT):
             random_indices = sorted(np.random.choice(local_explanation.eval_data.shape[0], Defaults.EVAL_DATA_VIZ_LIMIT, replace=False))
@@ -1256,7 +1255,6 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         else:
             eval_data_for_viz = local_explanation.eval_data
         setattr(local_explanation, ExplainParams.EVAL_DATA_VIZ, eval_data_for_viz)
-
     return local_explanation
 
 

--- a/visualization/dashboard/src/Localization/en-with-comments.json
+++ b/visualization/dashboard/src/Localization/en-with-comments.json
@@ -1,0 +1,191 @@
+{
+    // Prompts the user to select a point
+    "selectPoint": "Select a point to see its local explanation",
+    // models that output classes have this as the default class names
+    "defaultClassNames": "Class {0}",
+    // the default column names 
+    "defaultFeatureNames": "Feature {0}",
+    // https://en.wikipedia.org/wiki/Norm_(mathematics) Absolute value norm
+    "absoluteAverage": "Average of absolute value",
+    // Norm based on the predicted class rather than absolute value as above
+    "predictedClass": "Predicted class",
+    // Label for tab showing scatterplot of dataset and predictions
+    "dataExploration": "Data Exploration",
+    // Label for tab showing bar chart of importance of features at a global level
+    "globalImportance": "Global Importance",
+    // Label for tab showing scatter plot of dataset and importance of features data
+    "explanationExploration": "Explanation Exploration",
+    // Label showing all importance of feature datapoints in scatter plot
+    "summaryImportance": "Summary Importance",
+    // Label for feature importance 
+    "featureImportance": "Feature Importance",
+    // Label for local tab allowing the user to change parameters on a selected point
+    "perturbationExploration": "Perturbation Exploration",
+    // Lable for local tab showing feature importance of selected point
+    "localFeatureImportance": "Local Feature Importance",
+    // Label for tab showing https://christophm.github.io/interpretable-ml-book/ice.html
+    "ice": "ICE",
+    "clearSelection": "Clear selection",
+    "feature": "Feature:",
+    // The label for the linear intercept, the bias value
+    "intercept": "Intercept",
+    "ExplanationScatter": {
+        // prepend in frot of column nmaes
+        "dataLabel": "Data : {0}",
+        // prepend in front of feature importance of column nmae
+        "importanceLabel": "Importance : {0}",
+        // predicted output
+        "predictedY": "PredictedY",
+        // the index value (an integer of the row number)
+        "index": "Index",
+        "dataGroupLabel": "Data",
+        "output": "Output",
+        // Probability prefix for all classes in a multiclass problem
+        "probabilityLabel": "Probability : {0}",
+        // The true value to be predicted
+        "trueY": "True Y",
+        // label for predicted class
+        "class": "class: ",
+        // label for x value dropdown
+        "xValue": "X value:",
+        // label for y value dropdown
+        "yValue": "Y value:",
+        // label for selecting color value
+        "colorValue": "Color:"
+    },
+    "CrossClass": {
+        // label for dropdown allowing user to select how importance across multiple output classes is aggregated
+        "label": "Cross-class weighting:",
+        // tooltip on hover
+        "info": "Info",
+        // explains cross-class weighting
+        "overviewInfo": "Multiclass models generate an independent feature importance vector for each class. Each class's feature importance vector demonstrates which features made a class more likely or less likely. You can select how the weights of the per-class feature importance vectors are summarized into a single value:",
+        // explains absolute value weights
+        "absoluteValInfo": "Average of absolute value: Shows the sum of the feature's importance across all possible classes, divided by number of classes",
+        // explains predicted class weight
+        "predictedClassInfo": "Predicted class: Shows the feature importance value for a given point's predicted class",
+        // explains the weights for selecting a single class
+        "enumeratedClassInfo": "Enumerated class names: Shows only the specified class's feature importance values across all data points.",
+        "close": "Close"
+    },
+    "AggregateImportance": {
+        // The chart shows all data in a color scale (normalized to 0 - 1). This is the label for the color bar
+        "scaledFeatureValue": "Scaled Feature Value",
+        // The low end of the color bar
+        "low": "Low",
+        /// label for the high end of the color bar
+        "high": "High",
+        // Prefix to the feature name 
+        "featureLabel": "Feature: {0}",
+        // prefix to the feature value
+        "valueLabel": "Feature value: {0}",
+        // prefix to the feature importance
+        "importanceLabel": "Importance: {0}",
+        // prefixed in front of the output class names predicted by the model
+        "predictedClassTooltip": "Predicted Class: {0}",
+        // prefixed in front of the true class labels
+        "trueClassTooltip": "True Class: {0}",
+        // prefixed in front of the output in a regression model (numeric, no classes)
+        "predictedOutputTooltip": "Predicted Output: {0}",
+        // prefixed in front of the true value in a regression model (numeric, no classes)
+        "trueOutputTooltip": "True Output: {0}",
+        // Label for slider to show only the top (k) most important features, where the slider is used to set the value of k
+        "topKFeatures": "Top K Features:",
+        // Label for dropdown option, group data by the predicted value from the model (numeric values)
+        "predictedValue": "Predicted Value",
+        // Label for dropdown option, group data by predicted class from model
+        "predictedClass": "Predicted Class",
+        // label for dropdown option, group data by true value (numeric)
+        "trueValue": "True Value",
+        // label for dropdown, group data by true class
+        "trueClass": "True Class",
+        // label for dropdown, do not apply any grouping
+        "noColor": "None",
+        // error message if the dataset is too large to visualize
+        "tooManyRows": "The provided dataset is larger than this chart can support"
+    },
+    "BarChart": {
+        // Prefix for class 
+        "classLabel": "Class: {0}",
+        // prompt for setting how values are sorted
+        "sortBy": "Sort by",
+        // Error message for no applicable data
+        "noData": "No Data",
+        // sorting option, sort by the absolute value of the importance of all datapoints
+        "absoluteGlobal": "Absolute global",
+        // sorting option, sort by the absolute value of the importance for the single selected point
+        "absoluteLocal": "Absolute local",
+        // loading message
+        "calculatingExplanation": "Calculating explanation"
+    },
+    "IcePlot": {
+        // error message if non-numeric characters typed
+        "numericError": "Must be numeric",
+        // error message if non-integer values typed by user
+        "integerError": "Must be an integer",
+        // Prediction label for y-axis
+        "prediction": "Prediction",
+        // predicted probability label for y-axis
+        "predictedProbability": "Predicted probability",
+        // prediction hover prefix
+        "predictionLabel": "Prediction: {0}",
+        // probability hover prefix
+        "probabilityLabel": "Probability: {0}",
+        // error message for no model present
+        "noModelError": "Please provide an operationalized model to explore predictions in ICE plots.",
+        // feature dropdown label
+        "featurePickerLabel": "Feature:",
+        // Set minimum bounds label
+        "minimumInputLabel": "Minimum:",
+        // set maximum bounds label
+        "maximumInputLabel": "Maximum:",
+        // number of samples to include between minimum and maximum (integer)
+        "stepInputLabel": "Steps:",
+        // loading message
+        "loadingMessage": "Loading data...",
+        // prompt to user giving instructions to enter a numeric range
+        "submitPrompt": "Submit a range to view an ICE plot",
+        // error message for any parameter issue
+        "topLevelErrorMessage": "Error in parameter",
+        // prefix in front of external error
+        "errorPrefix": "Error encountered: {0}"
+    },
+    "PerturbationExploration": {
+        // loading message
+        "loadingMessage": "Loading...",
+        // Perturbation (ie. the user has made a set of small changes to the original data -- a perturbation. This is the label for the resulting prediction)
+        "perturbationLabel": "Perturbation:"
+    },
+    "PredictionLabel": {
+        // label for prediction of numeric values
+        "predictedValueLabel": "Predicted value : {0}",
+        // label for prediction of class value
+        "predictedClassLabel": "Predicted class : {0}"
+    },
+    "Violin": {
+        // Do not group data option
+        "groupNone": "No grouping",
+        // option to group data by predicted class
+        "groupPredicted": "Predicted Y",
+        // option to group data by true class
+        "groupTrue": "True Y",
+        // Group by prompt for dropdown to select how data should be grouped
+        "groupBy": "Group by"
+    },
+    "FeatureImportanceWrapper": {
+        // label for dropdown to select chart format
+        "chartType": "Chart type:",
+        //  a violin plot https://en.wikipedia.org/wiki/Violin_plot
+        "violinText": "Violin",
+        // a bar plot 
+        "barText": "Bar",
+        // a box plot https://en.wikipedia.org/wiki/Box_plot
+        "boxText": "Box",
+        // A swarm plot (its like a scatter plot with categorical x axis with dithering, see examples https://seaborn.pydata.org/generated/seaborn.swarmplot.html)
+        "beehiveText": "Swarm",
+        // explains how global feature importance is calculated 
+        "globalImportanceExplanation": "Global feature importance is calculated by averaging the absolute value of the feature importance of all points (L1 normalization). ",
+        // explains how global importance is calculated for each class in a multiclass case.
+        "multiclassImportanceAddendum": "All points are included in calculating a feature's importance for all classes, no differential weighting is used. So a feature that has large negative importance for many points predicted to not be of 'Class A' will greatly increase that feature's 'Class A'  importance."
+    }
+}

--- a/visualization/dashboard/src/Localization/en.json
+++ b/visualization/dashboard/src/Localization/en.json
@@ -1,134 +1,190 @@
 {
     "selectPoint": "Select a point to see its local explanation",
+    
     "defaultClassNames": "Class {0}",
+    
     "defaultFeatureNames": "Feature {0}",
+
     "absoluteAverage": "Average of absolute value",
+    
     "predictedClass": "Predicted class",
+    
     "dataExploration": "Data Exploration",
+    
     "globalImportance": "Global Importance",
+    
     "explanationExploration": "Explanation Exploration",
+    
     "summaryImportance": "Summary Importance",
+    
     "featureImportance": "Feature Importance",
+    
     "perturbationExploration": "Perturbation Exploration",
+    
     "localFeatureImportance": "Local Feature Importance",
+
     "ice": "ICE",
     "clearSelection": "Clear selection",
     "feature": "Feature:",
+    
     "intercept": "Intercept",
     "ExplanationScatter": {
+        
         "dataLabel": "Data : {0}",
+        
         "importanceLabel": "Importance : {0}",
+        
         "predictedY": "PredictedY",
+
         "index": "Index",
         "dataGroupLabel": "Data",
         "output": "Output",
+        
         "probabilityLabel": "Probability : {0}",
+        
         "trueY": "True Y",
-        "class": "class",
+        
+        "class": "class: ",
+        
         "xValue": "X value:",
+        
         "yValue": "Y value:",
+        
         "colorValue": "Color:"
     },
     "CrossClass": {
+        
         "label": "Cross-class weighting:",
+        
         "info": "Info",
+
         "overviewInfo": "Multiclass models generate an independent feature importance vector for each class. Each class's feature importance vector demonstrates which features made a class more likely or less likely. You can select how the weights of the per-class feature importance vectors are summarized into a single value:",
+        
         "absoluteValInfo": "Average of absolute value: Shows the sum of the feature's importance across all possible classes, divided by number of classes",
+        
         "predictedClassInfo": "Predicted class: Shows the feature importance value for a given point's predicted class",
+        
         "enumeratedClassInfo": "Enumerated class names: Shows only the specified class's feature importance values across all data points.",
         "close": "Close"
     },
     "AggregateImportance": {
+
         "scaledFeatureValue": "Scaled Feature Value",
+        
         "low": "Low",
+
         "high": "High",
+        
         "featureLabel": "Feature: {0}",
+        
         "valueLabel": "Feature value: {0}",
+        
         "importanceLabel": "Importance: {0}",
+        
         "predictedClassTooltip": "Predicted Class: {0}",
+        
         "trueClassTooltip": "True Class: {0}",
+
         "predictedOutputTooltip": "Predicted Output: {0}",
+
         "trueOutputTooltip": "True Output: {0}",
+
         "topKFeatures": "Top K Features:",
-        "scaledFeatureValues": "Scaled Feature Values",
+
         "predictedValue": "Predicted Value",
+        
         "predictedClass": "Predicted Class",
+
         "trueValue": "True Value",
+        
         "trueClass": "True Class",
+        
         "noColor": "None",
+        
         "tooManyRows": "The provided dataset is larger than this chart can support"
     },
     "BarChart": {
+        
         "classLabel": "Class: {0}",
+        
         "sortBy": "Sort by",
+        
         "noData": "No Data",
+        
         "absoluteGlobal": "Absolute global",
+        
         "absoluteLocal": "Absolute local",
+        
         "calculatingExplanation": "Calculating explanation"
     },
     "IcePlot": {
+
         "numericError": "Must be numeric",
+
         "integerError": "Must be an integer",
+
         "prediction": "Prediction",
+
         "predictedProbability": "Predicted probability",
+        
         "predictionLabel": "Prediction: {0}",
+        
         "probabilityLabel": "Probability: {0}",
+        
         "noModelError": "Please provide an operationalized model to explore predictions in ICE plots.",
+        
         "featurePickerLabel": "Feature:",
+        
         "minimumInputLabel": "Minimum:",
+        
         "maximumInputLabel": "Maximum:",
+
         "stepInputLabel": "Steps:",
+        
         "loadingMessage": "Loading data...",
+        
         "submitPrompt": "Submit a range to view an ICE plot",
+        
         "topLevelErrorMessage": "Error in parameter",
+        
         "errorPrefix": "Error encountered: {0}"
     },
     "PerturbationExploration": {
+        
         "loadingMessage": "Loading...",
+
         "perturbationLabel": "Perturbation:"
     },
     "PredictionLabel": {
+        
         "predictedValueLabel": "Predicted value : {0}",
+        
         "predictedClassLabel": "Predicted class : {0}"
     },
     "Violin": {
+        
         "groupNone": "No grouping",
+        
         "groupPredicted": "Predicted Y",
+        
         "groupTrue": "True Y",
+        
         "groupBy": "Group by"
     },
     "FeatureImportanceWrapper": {
+        
         "chartType": "Chart type:",
+
         "violinText": "Violin",
+        
         "barText": "Bar",
+
         "boxText": "Box",
+
         "beehiveText": "Swarm",
+        
         "globalImportanceExplanation": "Global feature importance is calculated by averaging the absolute value of the feature importance of all points (L1 normalization). ",
+
         "multiclassImportanceAddendum": "All points are included in calculating a feature's importance for all classes, no differential weighting is used. So a feature that has large negative importance for many points predicted to not be of 'Class A' will greatly increase that feature's 'Class A'  importance."
-    },
-    "Fairness": {
-        "accuracyTab": "Fairness in Accuracy",
-        "opportunityTab": "Fairness in Opportunity",
-        "modelComparisonTab": "Model Comparison",
-        "tableTab": "Detail View",
-        "dataSpecifications": "Data Specifications",
-        "attributes": "Attributes",
-        "attributesCount": "{0} attributes",
-        "instanceCount": "{0} instances",
-        "Accuracy": {
-            "header": "How do you want to measure accuracy",
-            "body": "We have determined that your model generates {0} predictions. Based on the information, we recommend the following accuracy metrics:"
-        },
-        "Parity": {
-            "header": "Fairness measured in terms of disparity",
-            "body": "Disparity metrics quantify variation of your model's behavior across selected features. There are two kinds of disparity metrics: more to come...."
-        },
-        "Footer": {
-            "back": "Back",
-            "next": "Next"
-        },
-        "Report": {
-            "title": "Accuracy and fairness assessment"
-        }
     }
 }

--- a/visualization/dashboard/src/MLIDashboard/Controls/FeatureImportance/Beenhive.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/FeatureImportance/Beenhive.tsx
@@ -95,7 +95,7 @@ export class Beehive extends React.PureComponent<IGlobalFeatureImportanceProps, 
         _.set(plotlyProps, 'layout.xaxis.tickvals', sortVector.map((val, index) => index));
         if (explanationContext.modelMetadata.modelType === ModelTypes.binary) {
             _.set(plotlyProps, 'layout.yaxis.title',
-                `${localization.featureImportance}<br> ${localization.ExplanationScatter.class} : ${explanationContext.modelMetadata.classNames[0]}`);
+                `${localization.featureImportance}<br> ${localization.ExplanationScatter.class} ${explanationContext.modelMetadata.classNames[0]}`);
         }
         if (selectedOption === undefined || selectedOption.key === "none") {
             PlotlyUtils.clearColorProperties(plotlyProps);

--- a/visualization/dashboard/src/MLIDashboard/ExplanationDashboard.tsx
+++ b/visualization/dashboard/src/MLIDashboard/ExplanationDashboard.tsx
@@ -356,6 +356,9 @@ export class ExplanationDashboard extends React.Component<IExplanationDashboardP
 
     constructor(props: IExplanationDashboardProps) {
         super(props);
+        if (this.props.locale) {
+            localization.setLanguage(this.props.locale)
+        }
         const explanationContext: IExplanationContext = ExplanationDashboard.buildInitialExplanationContext(props);
         const defaultTopK = Math.min(8, explanationContext.modelMetadata.featureNames.length);
         this.onClassSelect = this.onClassSelect.bind(this);

--- a/visualization/dashboard/src/MLIDashboard/Interfaces/IExplanationDashboardProps.ts
+++ b/visualization/dashboard/src/MLIDashboard/Interfaces/IExplanationDashboardProps.ts
@@ -24,6 +24,7 @@ export interface IExplanationDashboardProps {
     trueY?: number[];
     precomputedExplanations?: IPrecomputedExplanations;
     theme?: any;
+    locale?: string;
     stringParams?: IStringsParam;
     requestPredictions?: (request: any[], abortSignal: AbortSignal) => Promise<any[]>;
     requestLocalFeatureExplanations?: (request: any[], abortSignal: AbortSignal, explanationAlgorithm?: string) => Promise<any[]>;


### PR DESCRIPTION
eval_data is an input to explain_xxx(), and has been kept on the Explanation object in the 'eval_data' property.

This field would not be included in a serialization, upload/download of the Explanation.

To support consistent visualization of Explanations, we want to maintain a 'eval_data_viz' property on the Explanation that IS suitable for serialization and upload/download.

We establish a limit on the size of (configurable) 5K rows (an amount suitable for viz) so when eval_data is > 5K it will be randomly sampled down to 5K.