### PR TITLE
Adding eval_data_viz to Explanation

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -48,6 +48,7 @@ class ExplainParams(object):
     CLASSES = 'classes'
     CLASSIFICATION = 'classification'
     EVAL_DATA = 'eval_data'
+    EVAL_DATA_VIZ = 'eval_data_viz'
     EVAL_Y_PRED = 'eval_y_predicted'
     EVAL_Y_PRED_PROBA = 'eval_y_predicted_proba'
     EXPECTED_VALUES = 'expected_values'
@@ -97,6 +98,7 @@ class Defaults(object):
     # See this github repo for more details: https://github.com/scikit-learn-contrib/hdbscan
     HDBSCAN = 'hdbscan'
     MAX_DIM = 50
+    EVAL_DATA_VIZ_LIMIT = 5000
 
 
 class Attributes(object):

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1250,11 +1250,13 @@ def _create_local_explanation(expected_values=None, classification=True, explana
     local_explanation = DynamicLocalExplanation(explanation_id=exp_id, **kwargs)
     if hasattr(local_explanation, ExplainParams.EVAL_DATA):
         if (len(local_explanation.eval_data) > Defaults.EVAL_DATA_VIZ_LIMIT):
-            random_indices = sorted(np.random.choice(local_explanation.eval_data.shape[0], Defaults.EVAL_DATA_VIZ_LIMIT, replace=False))
+            random_indices = sorted(np.random.choice(local_explanation.eval_data.shape[0],
+                                    Defaults.EVAL_DATA_VIZ_LIMIT, replace=False))
             eval_data_for_viz = local_explanation.eval_data[random_indices]
         else:
             eval_data_for_viz = local_explanation.eval_data
-        setattr(local_explanation, ExplainParams.EVAL_DATA_VIZ, eval_data_for_viz)
+        setattr(local_explanation, ExplainParams.EVAL_DATA_VIZ,
+                eval_data_for_viz)
     return local_explanation
 
 
@@ -1356,7 +1358,8 @@ def _create_global_explanation(local_explanation=None, expected_values=None,
     DynamicGlobalExplanation = type(Dynamic.GLOBAL_EXPLANATION, tuple(mixins), {})
     global_explanation = DynamicGlobalExplanation(**kwargs)
     if hasattr(local_explanation, ExplainParams.EVAL_DATA_VIZ):
-        setattr(global_explanation, ExplainParams.EVAL_DATA_VIZ, getattr(local_explanation, ExplainParams.EVAL_DATA_VIZ))
+        setattr(global_explanation, ExplainParams.EVAL_DATA_VIZ,
+                getattr(local_explanation, ExplainParams.EVAL_DATA_VIZ))
     return global_explanation
 
 

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1248,6 +1248,13 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_ID] = model_id
     DynamicLocalExplanation = type(Dynamic.LOCAL_EXPLANATION, tuple(mixins), {})
     local_explanation = DynamicLocalExplanation(explanation_id=exp_id, **kwargs)
+    if hasattr(local_explanation, ExplainParams.EVAL_DATA):
+        if (len(local_explanation.eval_data) > Defaults.EVAL_DATA_VIZ_LIMIT):
+            random_indices = sorted(np.random.choice(local_explanation.eval_data.shape[0], Defaults.EVAL_DATA_VIZ_LIMIT, replace=False))
+            eval_data_for_viz = local_explanation.eval_data[random_indices]
+        else:
+            eval_data_for_viz = local_explanation.eval_data
+        setattr(local_explanation, ExplainParams.EVAL_DATA_VIZ, eval_data_for_viz)
     return local_explanation
 
 
@@ -1348,6 +1355,8 @@ def _create_global_explanation(local_explanation=None, expected_values=None,
                                                        classification, explanation_id, **kwargs)
     DynamicGlobalExplanation = type(Dynamic.GLOBAL_EXPLANATION, tuple(mixins), {})
     global_explanation = DynamicGlobalExplanation(**kwargs)
+    if hasattr(local_explanation, ExplainParams.EVAL_DATA_VIZ):
+        setattr(global_explanation, ExplainParams.EVAL_DATA_VIZ, getattr(local_explanation, ExplainParams.EVAL_DATA_VIZ))
     return global_explanation
 
 


### PR DESCRIPTION
eval_data is an input to explain_xxx(), and has been kept on the Explanation object in the 'eval_data' property.

This field would not be included in a serialization, upload/download of the Explanation.

To support consistent visualization of Explanations, we want to maintain a 'eval_data_viz' property on the Explanation that IS suitable for serialization and upload/download.

We establish a limit on the size of (configurable) 5K rows (an amount suitable for viz) so when eval_data is > 5K it will be randomly sampled down to 5K.