### PR TITLE
Add proposal for a preprocessing hook

### DIFF
--- a/python/interpret_community/__init__.py
+++ b/python/interpret_community/__init__.py
@@ -9,8 +9,9 @@ confidence in the model.
 """
 
 from .tabular_explainer import TabularExplainer
+from .preprocessing import add_preprocessing
 
-__all__ = ["TabularExplainer"]
+__all__ = ["TabularExplainer", "add_preprocessing"]
 
 # Setup logging infrustructure
 import logging

--- a/python/interpret_community/community/__init__.py
+++ b/python/interpret_community/community/__init__.py
@@ -1,9 +1,0 @@
-# ---------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# ---------------------------------------------------------
-
-"""Module for model interpretability, including feature and class importances for blackbox and greybox models."""
-
-from .tabular_explainer import TabularExplainer
-
-__all__ = ["TabularExplainer"]

--- a/python/interpret_community/dataset/dataset_wrapper.py
+++ b/python/interpret_community/dataset/dataset_wrapper.py
@@ -8,9 +8,9 @@ import pandas as pd
 import scipy as sp
 import numpy as np
 
-from ..common.explanation_utils import _summarize_data, _generate_augmented_data
-from ..common.explanation_utils import module_logger
-from ..common.constants import Defaults
+from interpret_community.common.explanation_utils import _summarize_data, _generate_augmented_data
+from interpret_community.common.explanation_utils import module_logger
+from interpret_community.common.constants import Defaults
 from sklearn.base import TransformerMixin, BaseEstimator
 from pandas.api.types import is_datetime64_any_dtype as is_datetime
 

--- a/python/interpret_community/preprocessing.py
+++ b/python/interpret_community/preprocessing.py
@@ -1,0 +1,13 @@
+PREPROCESSOR_KEY = "preprocessors"
+
+
+def add_preprocessing(base_class):
+    base_class_init = base_class.__init__
+
+    def new_init(self, func, data, *args, **kwargs):
+        if PREPROCESSOR_KEY in kwargs:
+            for preprocessor in kwargs.get(PREPROCESSOR_KEY):
+                data = preprocessor(data)
+        base_class_init(self, func, data, *args, **kwargs)
+    base_class.__init__ = new_init
+    return base_class

--- a/test/test_extension_proposal.py
+++ b/test/test_extension_proposal.py
@@ -1,0 +1,16 @@
+import pytest
+
+from interpret_community.preprocessing import add_preprocessing
+from interpret.blackbox import ShapKernel
+
+
+class CustomException(Exception):
+    pass
+
+
+def test_add_preprocessing():
+    with pytest.raises(CustomException):
+        def raise_exception():
+            raise CustomException("ran preprocess")
+
+        add_preprocessing(ShapKernel)(lambda x: 1, "a", preprocessors=[lambda a: raise_exception()])


### PR DESCRIPTION
Add hook for preprocessing the inputted data in interpretml. Preprocess is called on data in the init before the data is preprocessed by interpret.

The actual implementation will change but this shows the general concept and allows for pre/post processing of data.

Subsetting can be done with this method but it should be clear that the data is only available in the system in the preprocessed form(both forms are not available)