### PR TITLE
update shap dependency to 0.33.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -7,7 +7,8 @@ from setuptools import setup, find_packages
 import os
 import shutil
 
-_major = '0.3'
+_major = '0'
+_minor = '3'
 _patch = '1'
 
 README_FILE = 'README.md'
@@ -17,7 +18,7 @@ LICENSE_FILE = 'LICENSE.txt'
 if os.path.exists('../LICENSE'):
     shutil.copyfile('../LICENSE', LICENSE_FILE)
 
-VERSION = '{}.{}'.format(_major, _patch)
+VERSION = '{}.{}.{}'.format(_major, _minor, _patch)
 
 
 CLASSIFIERS = [

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,7 +8,7 @@ import os
 import shutil
 
 _major = '0.3'
-_minor = '1'
+_patch = '1'
 
 README_FILE = 'README.md'
 LICENSE_FILE = 'LICENSE.txt'
@@ -17,20 +17,7 @@ LICENSE_FILE = 'LICENSE.txt'
 if os.path.exists('../LICENSE'):
     shutil.copyfile('../LICENSE', LICENSE_FILE)
 
-if os.path.exists('../major.version'):
-    with open('../major.version', 'rt') as bf:
-        _major = str(bf.read()).strip()
-
-if os.path.exists('../minor.version'):
-    with open('../minor.version', 'rt') as bf:
-        _minor = str(bf.read()).strip()
-
-VERSION = '{}.{}'.format(_major, _minor)
-SELFVERSION = VERSION
-if os.path.exists('patch.version'):
-    with open('patch.version', 'rt') as bf:
-        _patch = str(bf.read()).strip()
-        SELFVERSION = '{}.{}'.format(VERSION, _patch)
+VERSION = '{}.{}'.format(_major, _patch)
 
 
 CLASSIFIERS = [
@@ -41,6 +28,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
     'Operating System :: Microsoft :: Windows',
     'Operating System :: MacOS',
@@ -54,7 +42,7 @@ DEPENDENCIES = [
     'scikit-learn',
     'packaging',
     'interpret-core[required]==0.1.19',
-    'shap>=0.20.0, <=0.32.1'
+    'shap>=0.20.0, <=0.33.0'
 ]
 
 EXTRAS = {
@@ -77,7 +65,7 @@ with open(README_FILE, 'r', encoding='utf-8') as f:
 setup(
     name='interpret-community',
 
-    version=SELFVERSION,
+    version=VERSION,
 
     description='Microsoft Interpret Extensions SDK for Python',
     long_description=README,
@@ -85,7 +73,7 @@ setup(
     author='Microsoft Corp',
     author_email='ilmat@microsoft.com',
     license='MIT License',
-    url='https://docs.microsoft.com/en-us/azure/machine-learning/service/',
+    url='https://github.com/interpretml/interpret-community',
 
     classifiers=CLASSIFIERS,
 


### PR DESCRIPTION
update shap dependency to 0.33.0
also some minor cleanup in setup.py:
- removed unused logic for major/patch version
- add python 3.7 classifier
- reference github url which should give interpret-community a github statistics panel on the pypi webpage