### PR TITLE
Made changes to AccessibleChart so that it is accessible by keyboard and Narrator

### DIFF
--- a/visualization/mlchartlib/package.json
+++ b/visualization/mlchartlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlchartlib",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "license": "MIT",
   "description": "Add accesibility, theming, and generating methods for plotly charts",
   "main": "rel/index.js",

--- a/visualization/mlchartlib/src/AccessibleChart.scss
+++ b/visualization/mlchartlib/src/AccessibleChart.scss
@@ -11,6 +11,17 @@
     display: none;
 }
 
+.visible-to-only-screen-reader {
+    border: 0; 
+    clip: rect(0 0 0 0); 
+    height: 1px; 
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}
+
 .LoadingScreen {
     top: 50%;
     left: 50%;

--- a/visualization/mlchartlib/src/AccessibleChart.tsx
+++ b/visualization/mlchartlib/src/AccessibleChart.tsx
@@ -75,6 +75,8 @@ export class AccessibleChart extends React.Component<AccessibleChartProps> {
                     <div
                         className="GridChart"
                         id={this.guid}
+                        aria-hidden={true}
+                        tabIndex={0}
                     />
                     {this.createTableWithPlotlyData(this.props.plotlyProps.data)}
                 </>
@@ -166,7 +168,7 @@ export class AccessibleChart extends React.Component<AccessibleChartProps> {
 
     private createTableWithPlotlyData(data: Plotly.Data[]): React.ReactNode {
         return (
-            <table className="plotly-table hidden">
+            <table className="plotly-table visible-to-only-screen-reader">
                 <tbody>
                     {data.map((datum, index) => {
                         const xDataLength = datum.x ? datum.x.length : 0;


### PR DESCRIPTION
Currently graph is not accessible by keyboard, and when using Narrator, it says "image" when going over the GridChart and does not pronounce date from the table.

This change is making it accessible by keyboard and when using Narrator, it pronounces values from the table (and skips GridChart)