### PR TITLE
Removed tabindex from GridChart

### DIFF
--- a/visualization/mlchartlib/package.json
+++ b/visualization/mlchartlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlchartlib",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "license": "MIT",
   "description": "Add accesibility, theming, and generating methods for plotly charts",
   "main": "rel/index.js",

--- a/visualization/mlchartlib/src/AccessibleChart.tsx
+++ b/visualization/mlchartlib/src/AccessibleChart.tsx
@@ -76,7 +76,6 @@ export class AccessibleChart extends React.Component<AccessibleChartProps> {
                         className="GridChart"
                         id={this.guid}
                         aria-hidden={true}
-                        tabIndex={0}
                     />
                     {this.createTableWithPlotlyData(this.props.plotlyProps.data)}
                 </>


### PR DESCRIPTION
Accessibility tests on our side are failing because having tabindex="0" and aria-hidden="true" is confusing. Tabindex allows item to be focusable by keyboard, but aria-hidden is hiding it from the Narrator.

Since we are currently not able to do anything on the chart after focusing with a keyboard (like going into each data point), we can just remove it.