### PR TITLE
Light doc pass.

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'interpret-community'
-copyright = '2019, Microsoft'
+copyright = '2020, Microsoft'
 author = 'Microsoft'
 
 # The full version, including alpha/beta/rc tags
@@ -37,7 +37,16 @@ extensions = [
 ]
 
 # eventually we may be able to use intersphinx for these! TODO
-autodoc_mock_imports = ['shap', 'interpret']
+autodoc_mock_imports = ['shap.common', 'interpret.utils']
+
+# enable links to objects in the other standard libraries, e.g., list and str in the Python standard library
+intersphinx_mapping = {
+    'Python': ('https://docs.python.org/3', None),
+    'NumPy': ('http://docs.scipy.org/doc/numpy/', None),
+    'pandas': ('http://pandas.pydata.org/pandas-docs/stable/', None),
+    'SciPy': ('http://docs.scipy.org/doc/scipy/reference', None),
+    'sklearn': ('http://scikit-learn.org/stable', None)
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -47,6 +56,8 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# The master toctree document.
+master_doc = 'index'
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -55,7 +55,7 @@ class BlackBoxMixin(ChainedIdentity):
 
     :param model: The model to explain or function if is_function is True.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
-    :param is_function: Default set to False. Set to True if passing sklearn.predict or sklearn.predict_proba
+    :param is_function: Default is False. Set to True if passing sklearn.predict or sklearn.predict_proba
         function instead of model.
     :type is_function: bool
     """
@@ -66,7 +66,7 @@ class BlackBoxMixin(ChainedIdentity):
         :param model: The model to explain or function if is_function is True.
         :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d
             ndarray
-        :param is_function: Default set to False. Set to True if passing sklearn.predict or sklearn.predict_proba
+        :param is_function: Default is False. Set to True if passing sklearn.predict or sklearn.predict_proba
             function instead of model.
         :type is_function: bool
         :param model_task: Optional parameter to specify whether the model is a classification or regression model.
@@ -143,7 +143,7 @@ class BlackBoxExplainer(BaseExplainer, BlackBoxMixin):
 
     :param model: The model to explain or function if is_function is True.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
-    :param is_function: Default set to false, set to True if passing sklearn.predict or sklearn.predict_proba
+    :param is_function: Default is false. Set to True if passing sklearn.predict or sklearn.predict_proba
         function instead of model.
     :type is_function: bool
     """
@@ -154,7 +154,7 @@ class BlackBoxExplainer(BaseExplainer, BlackBoxMixin):
         :param model: The model to explain or function if is_function is True.
         :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d
             ndarray
-        :param is_function: Default set to false, set to True if passing sklearn.predict or sklearn.predict_proba
+        :param is_function: Default is False. Set to True if passing sklearn.predict or sklearn.predict_proba
             function instead of model.
         :type is_function: bool
         """

--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -55,7 +55,7 @@ class BlackBoxMixin(ChainedIdentity):
 
     :param model: The model to explain or function if is_function is True.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
-    :param is_function: Default set to false, set to True if passing sklearn.predict or sklearn.predict_proba
+    :param is_function: Default set to False. Set to True if passing sklearn.predict or sklearn.predict_proba
         function instead of model.
     :type is_function: bool
     """
@@ -66,7 +66,7 @@ class BlackBoxMixin(ChainedIdentity):
         :param model: The model to explain or function if is_function is True.
         :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d
             ndarray
-        :param is_function: Default set to false, set to True if passing sklearn.predict or sklearn.predict_proba
+        :param is_function: Default set to False. Set to True if passing sklearn.predict or sklearn.predict_proba
             function instead of model.
         :type is_function: bool
         :param model_task: Optional parameter to specify whether the model is a classification or regression model.

--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -82,7 +82,7 @@ class ExplainParams(object):
     def get_serializable(cls):
         """Return only the ExplainParams properties that have meaningful data values for serialization.
 
-        :return: set of property names - e.g. 'GLOBAL_IMPORTANCE_VALUES', 'MODEL_TYPE', etc.
+        :return: A set of property names, e.g., 'GLOBAL_IMPORTANCE_VALUES', 'MODEL_TYPE', etc.
         :rtype: set{str}
         """
         return (set(filter(lambda x: not x.startswith('__') and not callable(getattr(cls, x)),
@@ -114,7 +114,7 @@ class Dynamic(object):
 
 
 class Tensorflow(object):
-    """Provide TensorFlow and Tensorboard related constants."""
+    """Provide TensorFlow and TensorBoard related constants."""
 
     CPU0 = '/CPU:0'
     TFLOG = 'tflog'
@@ -129,7 +129,7 @@ class SKLearn(object):
 
 
 class Spacy(object):
-    """Provide spacy related constants."""
+    """Provide spaCy related constants."""
 
     EN = 'en'
     NER = 'ner'
@@ -137,10 +137,10 @@ class Spacy(object):
 
 
 class ModelTask(str, Enum):
-    """Provide model task constants.  Can be classification, regression or unknown.
+    """Provide model task constants. Can be 'classification', 'regression', or 'unknown'.
 
-    By default we infer the model domain if Unknown, but this can be overridden by the user if they
-    specify classification or regression.
+    By default the model domain is inferred if 'unknown', but this can be overridden if you specify
+    'classification' or 'regression'.
     """
 
     Classification = 'classification'
@@ -155,9 +155,9 @@ class LightGBMParams(object):
 
 
 class ShapValuesOutput(str, Enum):
-    """Provide constants for the shap values output from the explainer.
+    """Provide constants for the SHAP values output from the explainer.
 
-    Can be default, probability or teacher_probability. If teacher probability is specified,
+    Can be 'default', 'probability' or 'teacher_probability'. If 'teacher_probability' is specified,
     we use the probabilities from the teacher model.
     """
 
@@ -252,16 +252,16 @@ class Extension(object):
 
 
 class SHAPDefaults(object):
-    """Provide constants for default values to shap."""
+    """Provide constants for default values to SHAP."""
 
     INDEPENDENT = 'independent'
 
 
 class ResetIndex(str, Enum):
-    """Provide index column handling constants.  Can be ignore, reset or reset_teacher.
+    """Provide index column handling constants. Can be 'ignore', 'reset' or 'reset_teacher'.
 
-    By default we ignore the index column, but the user can override to reset it and make it a
-    feature column that is then featurized to numeric or reset it and ignore it during
+    By default the index column is ignored, but you can override to reset it and make it a
+    feature column that is then featurized to numeric, or reset it and ignore it during
     featurization but set it as the index when calling predict on the original model.
     """
 

--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -59,13 +59,13 @@ def _summarize_data(X, k=10, to_round_values=True):
 
 
 def _get_raw_feature_importances(importance_values, raw_to_output_feature_maps):
-    """Return raw feature importances.
+    """Return raw feature importance values.
 
-    :param importance_values: importance values computed for the dataset
+    :param importance_values: The importance values computed for the dataset.
     :type importance_values: np.array
-    :param raw_to_output_feature_maps: list of feature maps from raw to generated feature.
+    :param raw_to_output_feature_maps: A list of feature maps from raw to generated feature.
     :type raw_to_output_feature_maps: list[numpy.array or sparse matrix]
-    :return: raw feature importances
+    :return: Raw feature importance values.
     :rtype: np.array
     """
     if not isinstance(raw_to_output_feature_maps, list):
@@ -105,7 +105,7 @@ def _multiply_sparse_matrix_3d_numpy_tensor(np_tensor, sp_matrix):
     :type np_tensor: numpy array
     :param sp_matrix: sparse matrix
     :type sp_matrix: scipy sparse matrix
-    :return: product of numpy array and sparse matrix
+    :return: The product of numpy array and sparse matrix.
     :rtype: numpy array
     """
     if len(np_tensor.shape) != 3:

--- a/python/interpret_community/common/metrics.py
+++ b/python/interpret_community/common/metrics.py
@@ -17,7 +17,7 @@ def dcg(validate_order, ground_truth_order_relevance, top_values=10):
     :type validate_order: list
     :param ground_truth_order_relevance: The ground truth relevancy of the documents to compare to.
     :type ground_truth_order_relevance: list
-    :param top_values: Specifies the top values to compute the DCG for, default to 10.
+    :param top_values: Specifies the top values to compute the DCG for. The default is 10.
     :type top_values: int
     """
     # retrieve relevance score for each value in validation order
@@ -37,11 +37,11 @@ def ndcg(validate_order, ground_truth_order, top_values=10):
     and the least possible NDCG is 0.0.
     See https://en.wikipedia.org/wiki/Discounted_cumulative_gain for reference.
 
-    :param validate_order: The order to validate for the documents.  The values should be unique.
+    :param validate_order: The order to validate for the documents. The values should be unique.
     :type validate_order: list
-    :param ground_truth_order: The true order of the documents.  The values should be unique.
+    :param ground_truth_order: The true order of the documents. The values should be unique.
     :type ground_truth_order: list
-    :param top_values: Specifies the top values to compute the NDCG for, default to 10.
+    :param top_values: Specifies the top values to compute the NDCG for. The default is 10.
     :type top_values: int
     """
     # Create map from true_order to "relevance" or reverse order index

--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -25,7 +25,7 @@ try:
     import torch
     import torch.nn as nn
 except ImportError:
-    module_logger.debug('Could not import torch, required if using a pytorch model')
+    module_logger.debug('Could not import torch, required if using a PyTorch model')
 
 
 def _convert_to_two_cols(function, examples):
@@ -73,7 +73,7 @@ def _convert_to_two_cols(function, examples):
 
 
 class WrappedPytorchModel(object):
-    """A class for wrapping a Pytorch model in the scikit-learn specification."""
+    """A class for wrapping a PyTorch model in the scikit-learn specification."""
 
     def __init__(self, model):
         """Initialize the PytorchModelWrapper with the model and evaluation function."""
@@ -82,7 +82,7 @@ class WrappedPytorchModel(object):
         self._model.eval()
 
     def predict(self, dataset):
-        """Predict the output using the wrapped pytorch model.
+        """Predict the output using the wrapped PyTorch model.
 
         :param dataset: The dataset to predict on.
         :type dataset: DatasetWrapper
@@ -99,7 +99,7 @@ class WrappedPytorchModel(object):
         return result
 
     def predict_classes(self, dataset):
-        """Predict the class using the wrapped pytorch model.
+        """Predict the class using the wrapped PyTorch model.
 
         :param dataset: The dataset to predict on.
         :type dataset: DatasetWrapper
@@ -116,7 +116,7 @@ class WrappedPytorchModel(object):
         return result
 
     def predict_proba(self, dataset):
-        """Predict the output probability using the wrapped pytorch model.
+        """Predict the output probability using the wrapped PyTorch model.
 
         :param dataset: The dataset to predict_proba on.
         :type dataset: DatasetWrapper

--- a/python/interpret_community/common/policy.py
+++ b/python/interpret_community/common/policy.py
@@ -17,7 +17,7 @@ class SamplingPolicy(ChainedIdentity):
     :param allow_eval_sampling: Default to 'False'. Specify whether to allow sampling of evaluation data.
         If 'True', cluster the evaluation data and determine the optimal number
         of points for sampling. Set to 'True' to speed up the process when the
-        evaluation data set is large and the user only wants to generate model
+        evaluation data set is large and you only want to generate model
         summary info.
     :type allow_eval_sampling: bool
     :param max_dim_clustering: Default to 50 and only take effect when 'allow_eval_sampling' is
@@ -32,7 +32,7 @@ class SamplingPolicy(ChainedIdentity):
     :param sampling_method: The sampling method for determining how much to downsample the evaluation data by.
         If allow_eval_sampling is True, the evaluation data is downsampled to a max_threshold, and then this
         heuristic is used to determine how much more to downsample the evaluation data without losing accuracy
-        on the calculated feature importance values.  By default, this is set to hdbscan, but the user can
+        on the calculated feature importance values.  By default, this is set to hdbscan, but you can
         also specify kmeans.  With hdbscan the number of clusters is automatically determined and multiplied by
         a threshold.  With kmeans, the optimal number of clusters is found by running KMeans until the maximum
         silhouette score is calculated, with k halved each time.
@@ -48,7 +48,7 @@ class SamplingPolicy(ChainedIdentity):
         :param allow_eval_sampling: Default to 'False'. Specify whether to allow sampling of evaluation data.
             If 'True', cluster the evaluation data and determine the optimal number
             of points for sampling. Set to 'True' to speed up the process when the
-            evaluation data set is large and the user only wants to generate model
+            evaluation data set is large and you only want to generate model
             summary info.
         :type allow_eval_sampling: bool
         :param max_dim_clustering: Default to 50 and only take effect when 'allow_eval_sampling' is
@@ -64,9 +64,10 @@ class SamplingPolicy(ChainedIdentity):
             If allow_eval_sampling is True, the evaluation data is downsampled to a max_threshold, and then this
             heuristic is used to determine how much more to downsample the evaluation data without losing accuracy
             on the calculated feature importance values.  By default, this is set to hdbscan, but the user can
-            also specify kmeans.  With hdbscan the number of clusters is automatically determined and multiplied by
-            a threshold.  With kmeans, the optimal number of clusters is found by running KMeans until the maximum
-            silhouette score is calculated, with k halved each time.
+            also specify kmeans. With hdbscan the number of clusters is automatically determined and multiplied by
+            a threshold. With kmeans, the optimal number of clusters is found by running KMeans until the maximum
+            silhouette score is calculated, with k halved each time. For more information about hbdscan, see
+            https://github.com/scikit-learn-contrib/hdbscan.
         :type sampling_method: str
         :rtype: dict
         :return: The arguments for the sampling policy

--- a/python/interpret_community/common/progress.py
+++ b/python/interpret_community/common/progress.py
@@ -17,7 +17,7 @@ def get_tqdm(logger, show_progress):
     :param show_progress: Default to 'True'.  Determines whether to display the explanation status bar
         when using PFIExplainer.
     :type show_progress: bool
-    :return: The tqdm progress bar.
+    :return: The tqdm (https://github.com/tqdm/tqdm) progress bar.
     :rtype: function
     """
     # This is used to get around code style build error F811

--- a/python/interpret_community/community/__init__.py
+++ b/python/interpret_community/community/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-"""Module for model interpretability, including feature and class importances for blackbox and greybox models."""
+"""Module for model interpretability, including feature and class importance for blackbox and greybox models."""
 
 from .tabular_explainer import TabularExplainer
 

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -29,10 +29,10 @@ class BaseExplanation(ChainedIdentity):
 
     :param method: The explanation method used to explain the model (e.g. SHAP, LIME).
     :type method: str
-    :param model_task: The task of the original model i.e. classification or regression.
+    :param model_task: The task of the original model i.e., classification or regression.
     :type model_task: str
     :param model_type: The type of the original model that was explained,
-        e.g. sklearn.linear_model.LinearRegression.
+        e.g., sklearn.linear_model.LinearRegression.
     :type model_type: str
     :param explanation_id: The unique identifier for the explanation.
     :type explanation_id: str
@@ -45,10 +45,10 @@ class BaseExplanation(ChainedIdentity):
 
         :param method: The explanation method used to explain the model (e.g. SHAP, LIME).
         :type method: str
-        :param model_task: The task of the original model i.e. classification or regression.
+        :param model_task: The task of the original model i.e., classification or regression.
         :type model_task: str
         :param model_type: The type of the original model that was explained,
-            e.g. sklearn.linear_model.LinearRegression.
+            e.g., sklearn.linear_model.LinearRegression.
         :type model_type: str
         :param explanation_id: The unique identifier for the explanation.
         :type explanation_id: str
@@ -80,7 +80,7 @@ class BaseExplanation(ChainedIdentity):
 
     @property
     def model_task(self):
-        """Get the task of the original model, i.e. classification or regression (others possibly in the future).
+        """Get the task of the original model, i.e., classification or regression (others possibly in the future).
 
         :return: The task of the original model.
         :rtype: str
@@ -89,9 +89,9 @@ class BaseExplanation(ChainedIdentity):
 
     @property
     def id(self):
-        """Get the explanation id.
+        """Get the explanation ID.
 
-        :return: The explanation id.
+        :return: The explanation ID.
         :rtype: str
         """
         return self._id
@@ -199,7 +199,7 @@ class BaseExplanation(ChainedIdentity):
 
         :param explanation: The explanation to be validated.
         :type explanation: object
-        :return: True if valid, else False
+        :return: True if valid, else False.
         :rtype: bool
         """
         if not hasattr(explanation, ExplainParams.METHOD) or not isinstance(explanation.method, str):
@@ -268,7 +268,7 @@ class FeatureImportanceExplanation(BaseExplanation):
     def is_raw(self):
         """Get the raw explanation flag.
 
-        :return: A boolean, True if it's a raw explanation. False if engineered or unknown.
+        :return: True if it's a raw explanation. False if engineered or unknown.
         :rtype: bool
         """
         return self._is_raw
@@ -277,7 +277,7 @@ class FeatureImportanceExplanation(BaseExplanation):
     def is_engineered(self):
         """Get the engineered explanation flag.
 
-        :return: A boolean, True if it's an engineered explanation (specifically not raw). False if raw or unknown.
+        :return: True if it's an engineered explanation (specifically not raw). False if raw or unknown.
         :rtype: bool
         """
         return self._is_eng
@@ -880,9 +880,9 @@ class ExpectedValuesMixin(object):
 class ClassesMixin(object):
     """The explanation mixin for classes.
 
-    This mixin is added when the user specifies classes in the classification
-    scenario when creating a global or local explanation.
-    This is activated when the user specifies the classes parameter for global
+    This mixin is added when you specify classes in the classification
+    scenario for creating a global or local explanation.
+    This is activated when you specify the classes parameter for global
     or local explanations.
 
     :param classes: Class names as a list of strings. The order of

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -27,7 +27,7 @@ class BaseExplanation(ChainedIdentity):
 
     """The common explanation returned by explainers.
 
-    :param method: The explanation method used to explain the model (e.g. SHAP, LIME).
+    :param method: The explanation method used to explain the model (e.g., SHAP, LIME).
     :type method: str
     :param model_task: The task of the original model i.e., classification or regression.
     :type model_task: str
@@ -1625,9 +1625,9 @@ def _transform_value_for_load(paramkey, expldict, _metadata):
 def save_explanation(explanation):
     """Serialize the explanation.
 
-    :param explanation: the Explanation to be serialized
+    :param explanation: The Explanation to be serialized.
     :type explanation: Explanation
-    :return: JSON-formatted explanation data
+    :return: JSON-formatted explanation data.
     :rtype: str
     """
     paramkeys = list(ExplainParams.get_serializable())
@@ -1660,9 +1660,9 @@ def save_explanation(explanation):
 def load_explanation(expljson):
     """De-serialize the explanation.
 
-    :param expljson: JSON-formatted explanation data
+    :param expljson: JSON-formatted explanation data.
     :type expljson: str
-    :return: the original Explanation
+    :return: The original Explanation.
     :rtype: Explanation
     """
     expl = json.loads(expljson)

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -79,15 +79,16 @@ class MimicExplainer(BlackBoxExplainer):
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -100,14 +101,14 @@ class MimicExplainer(BlackBoxExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param shap_values_output: The shap values output from the explainer.  Only applies to
         tree-based models that are in terms of raw feature values instead of probabilities.
@@ -173,31 +174,38 @@ class MimicExplainer(BlackBoxExplainer):
         :param classes: Class names as a list of strings. The order of the class names should match
             that of the model output.  Only required if explaining classifier.
         :type classes: list[str]
-        :param transformations: sklearn.compose.ColumnTransformer object or a list of tuples describing the column name
-        and transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for the list of transformations is same as the one here:
-        https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-        already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
-        Examples for transformations that work:
-        [
-            (["col1", "col2"], sklearn_one_hot_encoder),
-            (["col3"], None) #col3 passes as is
-        ]
-        [
-            (["col1"], my_own_transformer),
-            (["col2"], my_own_transformer),
-        ]
-        Example of transformations that would raise an error since it cannot be interpreted as one to many:
-        [
-            (["col1", "col2"], my_own_transformer)
-        ]
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
-        mapping when taking a sequence of columns.
+        :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param shap_values_output: The shap values output from the explainer.  Only applies to
             tree-based models that are in terms of raw feature values instead of probabilities.

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -59,7 +59,7 @@ class MimicExplainer(BlackBoxExplainer):
     :param explainable_model_args: An optional map of arguments to pass to the explainable model
         for initialization.
     :type explainable_model_args: dict
-    :param is_function: Default set to false, set to True if passing function instead of model.
+    :param is_function: Default is False. Set to True if passing function instead of model.
     :type is_function: bool
     :param augment_data: If true, oversamples the initialization examples to improve surrogate
         model accuracy to fit teacher model. Useful for high-dimensional data where
@@ -155,7 +155,7 @@ class MimicExplainer(BlackBoxExplainer):
         :param explainable_model_args: An optional map of arguments to pass to the explainable model
             for initialization.
         :type explainable_model_args: dict
-        :param is_function: Default set to false, set to True if passing function instead of model.
+        :param is_function: Default is False. Set to True if passing function instead of model.
         :type is_function: bool
         :param augment_data: If true, oversamples the initialization examples to improve surrogate
             model accuracy to fit teacher model.  Useful for high-dimensional data where

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -46,7 +46,7 @@ class MimicExplainer(BlackBoxExplainer):
 
     """The Mimic Explainer for explaining black box models or functions.
 
-    :param model: The black box model or function (if is_function is True) to be explained.  Also known
+    :param model: The black box model or function (if is_function is True) to be explained. Also known
         as the teacher model.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
@@ -62,7 +62,7 @@ class MimicExplainer(BlackBoxExplainer):
     :param is_function: Default set to false, set to True if passing function instead of model.
     :type is_function: bool
     :param augment_data: If true, oversamples the initialization examples to improve surrogate
-        model accuracy to fit teacher model.  Useful for high-dimensional data where
+        model accuracy to fit teacher model. Useful for high-dimensional data where
         the number of rows is less than the number of columns.
     :type augment_data: bool
     :param max_num_of_augmentations: max number of times we can increase the input data size.
@@ -75,7 +75,7 @@ class MimicExplainer(BlackBoxExplainer):
     :param features: A list of feature names.
     :type features: list[str]
     :param classes: Class names as a list of strings. The order of the class names should match
-        that of the model output.  Only required if explaining classifier.
+        that of the model output. Only required if explaining classifier.
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
@@ -308,7 +308,7 @@ class MimicExplainer(BlackBoxExplainer):
         """Get the kwargs for explain_global to create a global explanation.
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
-            explain the model's output.  If specified, computes feature importances through aggregation.
+            explain the model's output.  If specified, computes feature importance through aggregation.
         :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param include_local: Include the local explanations in the returned global explanation.
             If evaluation examples are specified and include_local is False, will stream the local
@@ -365,13 +365,13 @@ class MimicExplainer(BlackBoxExplainer):
                        batch_size=Defaults.DEFAULT_BATCH_SIZE):
         """Globally explains the blackbox model using the surrogate model.
 
-        If evaluation_examples are unspecified, retrieves global feature importances from explainable
-        surrogate model.  Note this will not include per class feature importances.  If evaluation_examples
+        If evaluation_examples are unspecified, retrieves global feature importance from explainable
+        surrogate model.  Note this will not include per class feature importance. If evaluation_examples
         are specified, aggregates local explanations to global from the given evaluation_examples - which
-        computes both global and per class feature importances.
+        computes both global and per class feature importance.
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
-            explain the model's output.  If specified, computes feature importances through aggregation.
+            explain the model's output.  If specified, computes feature importance through aggregation.
         :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param include_local: Include the local explanations in the returned global explanation.
             If evaluation examples are specified and include_local is False, will stream the local

--- a/python/interpret_community/permutation/metric_constants.py
+++ b/python/interpret_community/permutation/metric_constants.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-"""Defines Metric Constants for PFIExplainer."""
+"""Defines metric constants for PFIExplainer."""
 
 from enum import Enum
 

--- a/python/interpret_community/permutation/permutation_importance.py
+++ b/python/interpret_community/permutation/permutation_importance.py
@@ -81,15 +81,16 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -102,15 +103,15 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
-    :type transformations: [tuple]
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
+    :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations.
     :type allow_all_transformations: bool
     :param seed: Random number seed for shuffling.
@@ -163,31 +164,39 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
         :param classes: Class names as a list of strings. The order of the class names should match
             that of the model output.  Only required if explaining classifier.
         :type classes: list[str]
-        :param transformations: List of tuples describing the column name and transformer. When transformations are
-            provided, explanations are of the features before the transformation. The format for
-            transformations is same as the one here: https://github.com/scikit-learn-contrib/sklearn-pandas.
-            If the user is using a transformation that is not in the list of sklearn.preprocessing transformations
-            that we support then we cannot take a list of more than one column as input for the transformation.
-            A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder,
-            MaxAbsScaler, MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer,
-            QuantileTransformer, RobustScaler, StandardScaler.
-            Examples for transformations that work:
-            [
-                (["col1", "col2"], sklearn_one_hot_encoder),
-                (["col3"], None) #col3 passes as is
-            ]
-            [
-                (["col1"], my_own_transformer),
-                (["col2"], my_own_transformer),
-            ]
-            Example of transformations that would raise an error since it cannot be interpreted as one to many:
-            [
-                (["col1", "col2"], my_own_transformer)
-            ]
-            This would not work since it is hard to make out whether my_own_transformer gives a many to many or
-            one to many mapping when taking a sequence of columns.
-        :type transformations: [tuple]
+        :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
+        :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool
         :param seed: Random number seed for shuffling.

--- a/python/interpret_community/permutation/permutation_importance.py
+++ b/python/interpret_community/permutation/permutation_importance.py
@@ -55,7 +55,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
     :param model: The black box model or function (if is_function is True) to be explained. Also known
         as the teacher model.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
-    :param is_function: Default set to False. Set to True if passing function instead of model.
+    :param is_function: Default is False. Set to True if passing function instead of model.
     :type is_function: bool
     :param metric: The metric name or function to evaluate the permutation.
         Note that if a metric function is provided, a higher value must be better.
@@ -139,7 +139,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
             as the teacher model.
         :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d
             ndarray
-        :param is_function: Default set to False. Set to True if passing function instead of model.
+        :param is_function: Default is False. Set to True if passing function instead of model.
         :type is_function: bool
         :param metric: The metric name or function to evaluate the permutation.
             Note that if a metric function is provided, a higher value must be better.

--- a/python/interpret_community/permutation/permutation_importance.py
+++ b/python/interpret_community/permutation/permutation_importance.py
@@ -52,13 +52,13 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
 
     """Defines the Permutation Feature Importance Explainer for explaining black box models or functions.
 
-    :param model: The black box model or function (if is_function is True) to be explained.  Also known
+    :param model: The black box model or function (if is_function is True) to be explained. Also known
         as the teacher model.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
-    :param is_function: Default set to false, set to True if passing function instead of model.
+    :param is_function: Default set to False. Set to True if passing function instead of model.
     :type is_function: bool
     :param metric: The metric name or function to evaluate the permutation.
-        Note that if a metric function is provided a higher value must be better.
+        Note that if a metric function is provided, a higher value must be better.
         Otherwise, take the negative of the function or set is_error_metric to True.
         By default, if no metric is provided, F1 Score is used for binary classification,
         F1 Score with micro average is used for multiclass classification and mean
@@ -69,7 +69,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
     :param is_error_metric: If custom metric function is provided, set to True if a higher
         value of the metric is better.
     :type is_error_metric: bool
-    :param explain_subset: List of feature indices. If specified, only selects a subset of the
+    :param explain_subset: List of feature indexes. If specified, only selects a subset of the
         features in the evaluation dataset for explanation. For permutation feature importance,
         we can shuffle, score and evaluate on the specified indexes when this parameter is set.
         This argument is not supported when transformations are set.
@@ -111,7 +111,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
         This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
         many mapping when taking a sequence of columns.
     :type transformations: [tuple]
-    :param allow_all_transformations: Allow many to many and many to one transformations
+    :param allow_all_transformations: Allow many to many and many to one transformations.
     :type allow_all_transformations: bool
     :param seed: Random number seed for shuffling.
     :type seed: int
@@ -119,7 +119,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
         is a classifier, set to True instead of the default False to use predict_proba instead of
         predict when calculating the metric.
     :type for_classifier_use_predict_proba: bool
-    :param show_progress: Default to 'True'.  Determines whether to display the explanation status bar
+    :param show_progress: Default to 'True'. Determines whether to display the explanation status bar
         when using PFIExplainer.
     :type show_progress: bool
     :param model_task: Optional parameter to specify whether the model is a classification or regression model.
@@ -135,14 +135,14 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
                  show_progress=True, model_task=ModelTask.Unknown, **kwargs):
         """Initialize the PFIExplainer.
 
-        :param model: The black box model or function (if is_function is True) to be explained.  Also known
+        :param model: The black box model or function (if is_function is True) to be explained. Also known
             as the teacher model.
         :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d
             ndarray
-        :param is_function: Default set to false, set to True if passing function instead of model.
+        :param is_function: Default set to False. Set to True if passing function instead of model.
         :type is_function: bool
         :param metric: The metric name or function to evaluate the permutation.
-            Note that if a metric function is provided a higher value must be better.
+            Note that if a metric function is provided, a higher value must be better.
             Otherwise, take the negative of the function or set is_error_metric to True.
             By default, if no metric is provided, F1 Score is used for binary classification,
             F1 Score with micro average is used for multiclass classification and mean
@@ -153,7 +153,7 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
         :param is_error_metric: If custom metric function is provided, set to True if a higher
             value of the metric is better.
         :type is_error_metric: bool
-        :param explain_subset: List of feature indices. If specified, only selects a subset of the
+        :param explain_subset: List of feature indexes. If specified, only selects a subset of the
             features in the evaluation dataset for explanation. For permutation feature importance,
             we can shuffle, score and evaluate on the specified indexes when this parameter is set.
             This argument is not supported when transformations are set.

--- a/python/interpret_community/shap/__init__.py
+++ b/python/interpret_community/shap/__init__.py
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-"""Module for shap-based blackbox and greybox explainers."""
+"""Module for SHAP-based blackbox and greybox explainers."""
 from .deep_explainer import DeepExplainer
 from .kernel_explainer import KernelExplainer
 from .tree_explainer import TreeExplainer

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -153,8 +153,8 @@ class DeepExplainer(StructuredInitModelExplainer):
         The format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -217,8 +217,8 @@ class DeepExplainer(StructuredInitModelExplainer):
         transformer. When transformations are provided, explanations are of the features before the transformation. The
         format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -87,7 +87,7 @@ def _get_dnn_model_framework(model):
 
     TODO: Refactor out SHAP's code so we can reference this method directly from SHAP.
 
-    :return: The DNN Framework, Pytorch or Tensorflow.
+    :return: The DNN Framework, PyTorch or TensorFlow.
     :rtype: str
     """
     actual_model = model[0] if type(model) is tuple else model
@@ -95,7 +95,7 @@ def _get_dnn_model_framework(model):
 
 
 def _get_summary_data(initialization_examples, nclusters, framework):
-    """Compute the summary data from the intialization examples.
+    """Compute the summary data from the initialization examples.
 
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
@@ -126,10 +126,10 @@ class DeepExplainer(StructuredInitModelExplainer):
     available_explanations = [Extension.GLOBAL, Extension.LOCAL]
     explainer_type = Extension.GREYBOX
 
-    """An explainer for DNN models, implemented using shap's DeepExplainer, supports tensorflow and pytorch.
+    """An explainer for DNN models, implemented using shap's DeepExplainer, supports TensorFlow and PyTorch.
 
     :param model: The DNN model to explain.
-    :type model: pytorch or tensorflow model
+    :type model: PyTorch or TensorFlow model
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
     :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
@@ -194,7 +194,7 @@ class DeepExplainer(StructuredInitModelExplainer):
         """Initialize the DeepExplainer.
 
         :param model: The DNN model to explain.
-        :type model: pytorch or tensorflow model
+        :type model: PyTorch or TensorFlow model
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
         :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
@@ -369,13 +369,13 @@ class DeepExplainer(StructuredInitModelExplainer):
 
     @tabular_decorator
     def explain_local(self, evaluation_examples):
-        """Explain the model by using shap's deep explainer.
+        """Explain the model by using SHAP's deep explainer.
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
         :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: A model explanation object. It is guaranteed to be a LocalExplanation which also has the properties
-            of ExpectedValuesMixin. If the model is a classfier, it will have the properties of the ClassesMixin.
+            of ExpectedValuesMixin. If the model is a classifier, it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
         """
         kwargs = self._get_explain_local_kwargs(evaluation_examples)

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -150,15 +150,16 @@ class DeepExplainer(StructuredInitModelExplainer):
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
         If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -171,14 +172,14 @@ class DeepExplainer(StructuredInitModelExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations
     :type allow_all_transformations: bool
@@ -214,30 +215,37 @@ class DeepExplainer(StructuredInitModelExplainer):
             that of the model output.  Only required if explaining classifier.
         :type classes: list[str]
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
-        transformer. When transformations are provided, explanations are of the features before the transformation. The
-        format for list of transformations is same as the one here:
-        https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-        already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
-        Examples for transformations that work:
-        [
-            (["col1", "col2"], sklearn_one_hot_encoder),
-            (["col3"], None) #col3 passes as is
-        ]
-        [
-            (["col1"], my_own_transformer),
-            (["col2"], my_own_transformer),
-        ]
-        Example of transformations that would raise an error since it cannot be interpreted as one to many:
-        [
-            (["col1", "col2"], my_own_transformer)
-        ]
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
-        mapping when taking a sequence of columns.
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -71,15 +71,16 @@ class KernelExplainer(BlackBoxExplainer):
     :type show_progress: bool
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
         If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing transformations with a list of columns since these are
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -92,14 +93,14 @@ class KernelExplainer(BlackBoxExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations.
     :type allow_all_transformations: bool
@@ -151,30 +152,37 @@ class KernelExplainer(BlackBoxExplainer):
             when using shap_values from the KernelExplainer.
         :type show_progress: bool
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
-        transformer. When transformations are provided, explanations are of the features before the transformation. The
-        format for list of transformations is same as the one here:
-        https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If you areusing a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing transformations with a list of columns since these are
-        already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
-        Examples for transformations that work:
-        [
-            (["col1", "col2"], sklearn_one_hot_encoder),
-            (["col3"], None) #col3 passes as is
-        ]
-        [
-            (["col1"], my_own_transformer),
-            (["col2"], my_own_transformer),
-        ]
-        Example of transformations that would raise an error since it cannot be interpreted as one to many:
-        [
-            (["col1", "col2"], my_own_transformer)
-        ]
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
-        mapping when taking a sequence of columns.
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations.
         :type allow_all_transformations: bool

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -44,7 +44,7 @@ class KernelExplainer(BlackBoxExplainer):
         initializing the explainer.
     :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
         scipy.sparse.csr_matrix
-    :param is_function: Default set to False. Set to True if passing function instead of model.
+    :param is_function: Default set to False. Set to True if passing function instead of a model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
@@ -74,8 +74,8 @@ class KernelExplainer(BlackBoxExplainer):
         The format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -101,7 +101,7 @@ class KernelExplainer(BlackBoxExplainer):
         This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
         many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
-    :param allow_all_transformations: Allow many to many and many to one transformations
+    :param allow_all_transformations: Allow many to many and many to one transformations.
     :type allow_all_transformations: bool
     :param model_task: Optional parameter to specify whether the model is a classification or regression model.
         In most cases, the type of the model can be inferred based on the shape of the output, where a classifier
@@ -125,7 +125,7 @@ class KernelExplainer(BlackBoxExplainer):
             initializing the explainer.
         :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
             scipy.sparse.csr_matrix
-        :param is_function: Default set to false. Set to True if passing function instead of model.
+        :param is_function: Default set to false. Set to True if passing function instead of a model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation, which will speed up the explanation
@@ -154,8 +154,8 @@ class KernelExplainer(BlackBoxExplainer):
         transformer. When transformations are provided, explanations are of the features before the transformation. The
         format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you areusing a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -176,7 +176,7 @@ class KernelExplainer(BlackBoxExplainer):
         This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
         mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
-        :param allow_all_transformations: Allow many to many and many to one transformations
+        :param allow_all_transformations: Allow many to many and many to one transformations.
         :type allow_all_transformations: bool
         :param model_task: Optional parameter to specify whether the model is a classification or regression model.
             In most cases, the type of the model can be inferred based on the shape of the output, where a classifier
@@ -210,7 +210,8 @@ class KernelExplainer(BlackBoxExplainer):
     def _reset_evaluation_background(self, function, **kwargs):
         """Modify the explainer to use the new evaluation example for background data.
 
-        Note when constructing explainer an evaluation example is not available hence the initialization data is used.
+        Note: when constructing an explainer, an evaluation example is not available and hence the initialization
+        data is used.
 
         :param function: Function.
         :type function: Function that accepts a 2d ndarray

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -44,7 +44,7 @@ class KernelExplainer(BlackBoxExplainer):
         initializing the explainer.
     :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
         scipy.sparse.csr_matrix
-    :param is_function: Default set to False. Set to True if passing function instead of a model.
+    :param is_function: Default is False. Set to True if passing function instead of a model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
@@ -125,7 +125,7 @@ class KernelExplainer(BlackBoxExplainer):
             initializing the explainer.
         :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
             scipy.sparse.csr_matrix
-        :param is_function: Default set to false. Set to True if passing function instead of a model.
+        :param is_function: Default is False. Set to True if passing function instead of a model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation, which will speed up the explanation

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -36,7 +36,7 @@ class KernelExplainer(BlackBoxExplainer):
     available_explanations = [Extension.GLOBAL, Extension.LOCAL]
     explainer_type = Extension.BLACKBOX
 
-    """Tthe Kernel Explainer for explaining black box models or functions.
+    """The Kernel Explainer for explaining black box models or functions.
 
     :param model: The model to explain or function if is_function is True.
     :type model: model that implements sklearn.predict or sklearn.predict_proba or function that accepts a 2d ndarray
@@ -44,7 +44,7 @@ class KernelExplainer(BlackBoxExplainer):
         initializing the explainer.
     :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
         scipy.sparse.csr_matrix
-    :param is_function: Default set to false, set to True if passing function instead of model.
+    :param is_function: Default set to False. Set to True if passing function instead of model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
@@ -59,14 +59,14 @@ class KernelExplainer(BlackBoxExplainer):
     :param features: A list of feature names.
     :type features: list[str]
     :param classes: Class names as a list of strings. The order of the class names should match
-        that of the model output.  Only required if explaining classifier.
+        that of the model output. Only required if explaining classifier.
     :type classes: list[str]
     :param nclusters: Number of means to use for approximation. A dataset is summarized with nclusters mean
         samples weighted by the number of data points they each represent. When the number of initialization
         examples is larger than (10 x nclusters), those examples will be summarized with k-means where
         k = nclusters.
     :type nclusters: int
-    :param show_progress: Default to 'True'.  Determines whether to display the explanation status bar
+    :param show_progress: Default to 'True'. Determines whether to display the explanation status bar
         when using shap_values from the KernelExplainer.
     :type show_progress: bool
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
@@ -76,7 +76,7 @@ class KernelExplainer(BlackBoxExplainer):
 
         If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
         we support then we cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        A user can use the following sklearn.preprocessing transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
         StandardScaler.
@@ -125,7 +125,7 @@ class KernelExplainer(BlackBoxExplainer):
             initializing the explainer.
         :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
             scipy.sparse.csr_matrix
-        :param is_function: Default set to false, set to True if passing function instead of model.
+        :param is_function: Default set to false. Set to True if passing function instead of model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation, which will speed up the explanation
@@ -147,7 +147,7 @@ class KernelExplainer(BlackBoxExplainer):
             examples is larger than (10 x nclusters), those examples will be summarized with k-means where
             k = nclusters.
         :type nclusters: int
-        :param show_progress: Default to 'True'.  Determines whether to display the explanation status bar
+        :param show_progress: Default to 'True'. Determines whether to display the explanation status bar
             when using shap_values from the KernelExplainer.
         :type show_progress: bool
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
@@ -156,7 +156,7 @@ class KernelExplainer(BlackBoxExplainer):
         https://github.com/scikit-learn-contrib/sklearn-pandas.
         If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
         we support then we cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        A user can use the following sklearn.preprocessing transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
         StandardScaler.
@@ -208,7 +208,7 @@ class KernelExplainer(BlackBoxExplainer):
         self._reset_evaluation_background(self.function, **kwargs)
 
     def _reset_evaluation_background(self, function, **kwargs):
-        """Modify the explainer to use the new evalaution example for background data.
+        """Modify the explainer to use the new evaluation example for background data.
 
         Note when constructing explainer an evaluation example is not available hence the initialization data is used.
 
@@ -351,7 +351,7 @@ class KernelExplainer(BlackBoxExplainer):
             to explain the model's output.
         :type evaluation_examples: DatasetWrapper
         :return: A model explanation object. It is guaranteed to be a LocalExplanation which also has the properties
-            of ExpectedValuesMixin. If the model is a classfier, it will have the properties of the ClassesMixin.
+            of ExpectedValuesMixin. If the model is a classifier, it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
         """
         kwargs = self._get_explain_local_kwargs(evaluation_examples)

--- a/python/interpret_community/shap/kwargs_utils.py
+++ b/python/interpret_community/shap/kwargs_utils.py
@@ -10,10 +10,10 @@ from interpret_community.common.constants import ExplainParams
 def _get_explain_global_kwargs(sampling_policy, method, include_local, batch_size):
     """Get the kwargs for explain_global.
 
-    :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
+    :param sampling_policy: Optional policy for sampling the evaluation examples. See documentation on
         SamplingPolicy for more information.
-    :type sampling_policy: SamplingPolicy
-    :param method: The explanation method used, e.g. shap_kernel, mimic
+    :type sampling_policy: interpret_community.common.SamplingPolicy
+    :param method: The explanation method used, e.g., shap_kernel, mimic, etc.
     :type method: str
     :param include_local: Whether a local explanation should be generated or only global
     :type include_local: bool

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -50,15 +50,16 @@ class LinearExplainer(StructuredInitModelExplainer):
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
         If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -71,14 +72,14 @@ class LinearExplainer(StructuredInitModelExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations
     :type allow_all_transformations: bool
@@ -105,30 +106,37 @@ class LinearExplainer(StructuredInitModelExplainer):
             that of the model output.  Only required if explaining classifier.
         :type classes: list[str]
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
-        transformer. When transformations are provided, explanations are of the features before the transformation. The
-        format for list of transformations is same as the one here:
-        https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-        already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
-        Examples for transformations that work:
-        [
-            (["col1", "col2"], sklearn_one_hot_encoder),
-            (["col3"], None) #col3 passes as is
-        ]
-        [
-            (["col1"], my_own_transformer),
-            (["col2"], my_own_transformer),
-        ]
-        Example of transformations that would raise an error since it cannot be interpreted as one to many:
-        [
-            (["col1", "col2"], my_own_transformer)
-        ]
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
-        mapping when taking a sequence of columns.
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -53,8 +53,8 @@ class LinearExplainer(StructuredInitModelExplainer):
         The format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -108,8 +108,8 @@ class LinearExplainer(StructuredInitModelExplainer):
         transformer. When transformations are provided, explanations are of the features before the transformation. The
         format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -245,13 +245,13 @@ class LinearExplainer(StructuredInitModelExplainer):
 
     @tabular_decorator
     def explain_local(self, evaluation_examples):
-        """Explain the model by using shap's linear explainer.
+        """Explain the model by using SHAP's linear explainer.
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
         :type evaluation_examples: DatasetWrapper
         :return: A model explanation object. It is guaranteed to be a LocalExplanation which also has the properties
-            of ExpectedValuesMixin. If the model is a classfier, it will have the properties of the ClassesMixin.
+            of ExpectedValuesMixin. If the model is a classifier, it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
         """
         original_evals = evaluation_examples.original_dataset_with_type

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -43,20 +43,19 @@ class TreeExplainer(PureStructuredModelExplainer):
     :param features: A list of feature names.
     :type features: list[str]
     :param classes: Class names as a list of strings. The order of the class names should match
-        that of the model output.  Only required if explaining classifier.
+        that of the model output. Only required if explaining classifier.
     :type classes: list[str]
     :param shap_values_output: The type of the output when using TreeExplainer.
         Currently only types 'default' and 'probability' are supported.  If 'probability'
-        is specified, then we approximately scale the raw log-odds values from the TreeExplainer
-        to probabilities.
+        is specified, then the raw log-odds values are approximately scaled to probabilities from the TreeExplainer.
     :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
         The format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -105,15 +104,15 @@ class TreeExplainer(PureStructuredModelExplainer):
         :type classes: list[str]
         :param shap_values_output: The type of the output when using TreeExplainer.
             Currently only types 'default' and 'probability' are supported.  If 'probability'
-            is specified, then we approximately scale the raw log-odds values from the TreeExplainer
-            to probabilities.
+            is specified, then the raw log-odds values are approximately scaled to probabilities from the 
+            TreeExplainer.
         :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation. The
         format for list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
         MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
@@ -268,7 +267,7 @@ class TreeExplainer(PureStructuredModelExplainer):
             to explain the model's output.
         :type evaluation_examples: DatasetWrapper
         :return: A model explanation object. It is guaranteed to be a LocalExplanation which also has the properties
-            of ExpectedValuesMixin. If the model is a classfier, it will have the properties of the ClassesMixin.
+            of ExpectedValuesMixin. If the model is a classifier, it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
         """
         original_evals = evaluation_examples.original_dataset_with_type

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -51,15 +51,16 @@ class TreeExplainer(PureStructuredModelExplainer):
     :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
         If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
+        are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
+        You can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -72,14 +73,14 @@ class TreeExplainer(PureStructuredModelExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations
     :type allow_all_transformations: bool
@@ -108,30 +109,37 @@ class TreeExplainer(PureStructuredModelExplainer):
             TreeExplainer.
         :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
-        transformer. When transformations are provided, explanations are of the features before the transformation. The
-        format for list of transformations is same as the one here:
-        https://github.com/scikit-learn-contrib/sklearn-pandas.
-        If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
-        are supported, then this parameter cannot take a list of more than one column as input for the transformation.
-        A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-        already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
-        Examples for transformations that work:
-        [
-            (["col1", "col2"], sklearn_one_hot_encoder),
-            (["col3"], None) #col3 passes as is
-        ]
-        [
-            (["col1"], my_own_transformer),
-            (["col2"], my_own_transformer),
-        ]
-        Example of transformations that would raise an error since it cannot be interpreted as one to many:
-        [
-            (["col1", "col2"], my_own_transformer)
-        ]
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to many
-        mapping when taking a sequence of columns.
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
+            https://github.com/scikit-learn-contrib/sklearn-pandas.
+
+            If you are using a transformation that is not in the list of sklearn.preprocessing transformations that
+            are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
+            You can use the following sklearn.preprocessing  transformations with a list of columns since these are
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -104,7 +104,7 @@ class TreeExplainer(PureStructuredModelExplainer):
         :type classes: list[str]
         :param shap_values_output: The type of the output when using TreeExplainer.
             Currently only types 'default' and 'probability' are supported.  If 'probability'
-            is specified, then the raw log-odds values are approximately scaled to probabilities from the 
+            is specified, then the raw log-odds values are approximately scaled to probabilities from the
             TreeExplainer.
         :type shap_values_output: interpret_community.common.constants.ShapValuesOutput
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and

--- a/python/interpret_community/tabular_explainer.py
+++ b/python/interpret_community/tabular_explainer.py
@@ -42,15 +42,16 @@ class TabularExplainer(BaseExplainer):
     :type classes: list[str]
     :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
         transformer. When transformations are provided, explanations are of the features before the transformation.
-        The format for list of transformations is same as the one here:
+        The format for a list of transformations is same as the one here:
         https://github.com/scikit-learn-contrib/sklearn-pandas.
 
-        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations that
-        we support then we cannot take a list of more than one column as input for the transformation.
+        If the user is using a transformation that is not in the list of sklearn.preprocessing transformations
+        that are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+        package, then this parameter cannot take a list of more than one column as input for the transformation.
         A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
         already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
-        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer, RobustScaler,
-        StandardScaler.
+        MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+        RobustScaler, StandardScaler.
 
         Examples for transformations that work::
 
@@ -63,14 +64,14 @@ class TabularExplainer(BaseExplainer):
                 (["col2"], my_own_transformer),
             ]
 
-        Example of transformations that would raise an error since it cannot be interpreted as one to many::
+        An example of a transformation that would raise an error since it cannot be interpreted as one to many::
 
             [
                 (["col1", "col2"], my_own_transformer)
             ]
 
-        This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-        many mapping when taking a sequence of columns.
+        The last example would not work since the interpret-community package can't determine whether
+        my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
     :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
     :param allow_all_transformations: Allow many to many and many to one transformations
     :type allow_all_transformations: bool
@@ -99,30 +100,37 @@ class TabularExplainer(BaseExplainer):
             that of the model output.  Only required if explaining classifier.
         :type classes: list[str]
         :param transformations: sklearn.compose.ColumnTransformer or a list of tuples describing the column name and
-            transformer. When transformations are provided, explanations are of the features before the
-            transformation. The format for list of transformations is same as the one here:
+            transformer. When transformations are provided, explanations are of the features before the transformation.
+            The format for a list of transformations is same as the one here:
             https://github.com/scikit-learn-contrib/sklearn-pandas.
+
             If the user is using a transformation that is not in the list of sklearn.preprocessing transformations
-            that we support then we cannot take a list of more than one column as input for the transformation.
+            that are supported by the `interpret-community <https://github.com/interpretml/interpret-community>`_
+            package, then this parameter cannot take a list of more than one column as input for the transformation.
             A user can use the following sklearn.preprocessing  transformations with a list of columns since these are
-            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder,
-            MaxAbsScaler, MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer,
-            QuantileTransformer, RobustScaler, StandardScaler.
-            Examples for transformations that work:
-            [
-                (["col1", "col2"], sklearn_one_hot_encoder),
-                (["col3"], None) #col3 passes as is
-            ]
-            [
-                (["col1"], my_own_transformer),
-                (["col2"], my_own_transformer),
-            ]
-            Example of transformations that would raise an error since it cannot be interpreted as one to many:
-            [
-                (["col1", "col2"], my_own_transformer)
-            ]
-            This would not work since it is hard to make out whether my_own_transformer gives a many to many or one to
-            many mapping when taking a sequence of columns.
+            already one to many or one to one: Binarizer, KBinsDiscretizer, KernelCenterer, LabelEncoder, MaxAbsScaler,
+            MinMaxScaler, Normalizer, OneHotEncoder, OrdinalEncoder, PowerTransformer, QuantileTransformer,
+            RobustScaler, StandardScaler.
+
+            Examples for transformations that work::
+
+                [
+                    (["col1", "col2"], sklearn_one_hot_encoder),
+                    (["col3"], None) #col3 passes as is
+                ]
+                [
+                    (["col1"], my_own_transformer),
+                    (["col2"], my_own_transformer),
+                ]
+
+            An example of a transformation that would raise an error since it cannot be interpreted as one to many::
+
+                [
+                    (["col1", "col2"], my_own_transformer)
+                ]
+
+            The last example would not work since the interpret-community package can't determine whether
+            my_own_transformer gives a many to many or one to many mapping when taking a sequence of columns.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool

--- a/python/interpret_community/widget/explanation_dashboard.py
+++ b/python/interpret_community/widget/explanation_dashboard.py
@@ -23,13 +23,13 @@ from ._internal.constants import DatabricksInterfaceConstants
 :param true_y: The true labels for the provided dataset. Overwrites any existing dataset on the
     explanation object.
 :type true_y: numpy.array or list[]
-:param classes: The class names
+:param classes: The class names.
 :type classes: numpy.array or list[]
-:param features: Feature names
+:param features: Feature names.
 :type features: numpy.array or list[]
-:param port: the port to use on localhosted service
+:param port: The port to use on locally hosted service.
 :type port: number
-:param use_cdn: should load latest dashboard script from cdn, fall back to local script if false
+:param use_cdn: Whether to load latest dashboard script from cdn, fall back to local script if False.
 :type use_cdn: boolean
 """
 

--- a/python/interpret_community/widget/explanation_dashboard_input.py
+++ b/python/interpret_community/widget/explanation_dashboard_input.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 
 class ExplanationDashboardInput:
-    """Represents an explanation as all the pieces that can be serialized and passed to javascript"""
+    """Represents an explanation as all the pieces that can be serialized and passed to JavaScript."""
 
     def __init__(
             self,
@@ -31,15 +31,15 @@ class ExplanationDashboardInput:
             it has a method of predict_proba() returning the prediction probabilities for each
             class and for the regression case a method of predict() returning the prediction value.
         :type model: object
-        :param dataset:  A matrix of feature vector examples (# examples x # features), the same samples
+        :param dataset: A matrix of feature vector examples (# examples x # features), the same samples
             used to build the explanation. Will overwrite any set on explanation object already
         :type dataset: numpy.array or list[][]
         :param true_y: The true labels for the provided dataset. Will overwrite any set on
-            explanation object already
+            explanation object already.
         :type true_y: numpy.array or list[]
-        :param classes: The class names
+        :param classes: The class names.
         :type classes: numpy.array or list[]
-        :param features: Feature names
+        :param features: Feature names.
         :type features: numpy.array or list[]
         """
         self._model = model

--- a/python/scripts/build-docs.ps1
+++ b/python/scripts/build-docs.ps1
@@ -21,6 +21,12 @@ try
     $docbuildpath = [System.IO.Path]::Combine($rootpath, "docbuild")
     $docconfigpath = [System.IO.Path]::Combine($rootpath, "docs")
 
+    Write-Host "scriptpath::", $scriptpath
+    Write-Host "rootpath::", $rootpath
+    Write-Host "codepath::", $codepath
+    Write-Host "docbuildpath::", $docbuildpath
+    Write-Host "docconfigpath::", $docconfigpath
+
     # Make sure we have a clean slate
     Remove-Item -Path $docbuildpath -Recurse -Force -ErrorAction SilentlyContinue
 

--- a/python/scripts/build-docs.ps1
+++ b/python/scripts/build-docs.ps1
@@ -21,12 +21,6 @@ try
     $docbuildpath = [System.IO.Path]::Combine($rootpath, "docbuild")
     $docconfigpath = [System.IO.Path]::Combine($rootpath, "docs")
 
-    Write-Host "scriptpath::", $scriptpath
-    Write-Host "rootpath::", $rootpath
-    Write-Host "codepath::", $codepath
-    Write-Host "docbuildpath::", $docbuildpath
-    Write-Host "docconfigpath::", $docconfigpath
-
     # Make sure we have a clean slate
     Remove-Item -Path $docbuildpath -Recurse -Force -ErrorAction SilentlyContinue
 

--- a/test/test_explain_model.py
+++ b/test/test_explain_model.py
@@ -346,20 +346,31 @@ class TestTabularExplainer(object):
         assert len(explanation.local_importance_values) == len(iris[DatasetConstants.CLASSES])
         assert explanation.num_classes == len(iris[DatasetConstants.CLASSES])
 
-    def test_explain_model_lightgbm_binary(self, tabular_explainer):
+    def _validate_binary_explain_model(self, tabular_explainer, create_model, test_name):
         X, y = shap.datasets.adult()
         x_train, x_test, y_train, _ = train_test_split(X, y, test_size=0.2, random_state=7)
-        # Fit a tree model
-        model = create_lightgbm_classifier(x_train, y_train)
-
+        model = create_model(x_train, y_train)
         classes = ["<50k", ">50k"]
         # Create tabular explainer
         exp = tabular_explainer(model, x_train, features=X.columns.values,
                                 classes=classes)
-        test_logger.info('Running explain global for test_explain_model_lightgbm_binary')
+        test_logger.info('Running explain global for {}'.format(test_name))
         explanation = exp.explain_global(x_test)
         assert len(explanation.local_importance_values[0]) == len(x_test)
         assert len(explanation.local_importance_values) == len(classes)
+
+    @pytest.mark.skip
+    def test_explain_model_xgboost_binary(self, tabular_explainer):
+        # Fit an xgboost tree model
+        def create_model(x_train, y_train):
+            return create_xgboost_classifier(x_train, y_train)
+        self._validate_binary_explain_model(tabular_explainer, create_model, 'test_explain_model_xgboost_binary')
+
+    def test_explain_model_lightgbm_binary(self, tabular_explainer):
+        # Fit a lightgbm tree model
+        def create_model(x_train, y_train):
+            return create_lightgbm_classifier(x_train, y_train)
+        self._validate_binary_explain_model(tabular_explainer, create_model, 'test_explain_model_lightgbm_binary')
 
     def _explain_model_dnn_common(self, tabular_explainer, model, x_train, x_test, y_train, features):
         # Create tabular explainer


### PR DESCRIPTION
Changes just to docstrings, except to conf.py to get local builds to behave nicely in terms of linking.

In general:
1. changed "user" terminology to "you" to make it more personal
2. where "we" was used, either named actor or went with passive form of sentence 
3. checked for proper user of brand names.

