### PR TITLE
Changed plotly chart table to have display block

### DIFF
--- a/visualization/mlchartlib/package.json
+++ b/visualization/mlchartlib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlchartlib",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "license": "MIT",
   "description": "Add accesibility, theming, and generating methods for plotly charts",
   "main": "rel/index.js",

--- a/visualization/mlchartlib/src/AccessibleChart.scss
+++ b/visualization/mlchartlib/src/AccessibleChart.scss
@@ -12,8 +12,9 @@
 }
 
 .visible-to-only-screen-reader {
-    border: 0; 
-    clip: rect(0 0 0 0); 
+    border: 0;
+    clip: rect(0 0 0 0);
+    display: block;
     height: 1px; 
     margin: -1px;
     overflow: hidden;


### PR DESCRIPTION
Currently table is taking space with a lot of empty space on the page if there is a lot of data. Changing display to block resolves this issue.