### PR TITLE
improved gevent error message

### DIFF
--- a/python/interpret_community/widget/explanation_dashboard.py
+++ b/python/interpret_community/widget/explanation_dashboard.py
@@ -1,4 +1,3 @@
-from gevent.pywsgi import WSGIServer
 from flask import Flask, render_template, request
 from IPython.display import display, IFrame
 import threading
@@ -9,6 +8,11 @@ import json
 import atexit
 from .explanation_dashboard_input import ExplanationDashboardInput
 from ._internal.constants import DatabricksInterfaceConstants
+try:
+    from gevent.pywsgi import WSGIServer
+except ModuleNotFoundError:
+    raise RuntimeError("Error: gevent package is missing, please run 'conda install gevent' or"
+                       "'pip install gevent' or 'pip install interpret-community[visualization]'")
 
 """Explanation Dashboard Class.
 


### PR DESCRIPTION
improved gevent error message to be:

Error: gevent package is missing, please run 'conda install gevent' or 'pip install gevent' or 'pip install interpret-community[visualization]'