### PR TITLE
fix aggregation logic to use mean

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -22,7 +22,6 @@ from ..common.constants import Dynamic, ExplainParams, ExplanationParams, \
 from ..dataset.dataset_wrapper import DatasetWrapper
 from ..common.explanation_utils import _get_raw_feature_importances
 from ..common.chained_identity import ChainedIdentity
-from sklearn.utils.sparsefuncs import csc_median_axis_0
 
 
 class BaseExplanation(ChainedIdentity):
@@ -1423,8 +1422,8 @@ def _get_aggregate_kwargs(local_explanation=None, include_local=True,
     classification = ClassesMixin._does_quack(local_explanation)
     if classification:
         if local_explanation.is_local_sparse:
-            medians = [np.array(csc_median_axis_0(matrix.tocsc())) for matrix in local_importance_values]
-            per_class_values = np.array(medians)
+            means = [(np.array(abs(m).sum(axis=0)) / m.shape[0]).flatten() for m in local_importance_values]
+            per_class_values = np.array(means)
         else:
             per_class_values = np.mean(np.absolute(local_importance_values), axis=1)
         per_class_rank = _order_imp(per_class_values)


### PR DESCRIPTION
fix aggregation logic to use mean

We were seeing issues where only one column appeared in the global importance values with AutoML.

After AutoML featurization, all except one of the columns are TFIDF columns (and I'm guessing others are dropped).  When computing the global feature importance values for sparse data, I'm currently using median, which means that columns with very sparse feature importances will just have an importance value of 0.  Using median preserves sparsity, but it also makes most of the global feature importances zero, which seems like it might not be as useful.  I will update it to use mean instead.  Even if I use mean, most of the values will be very close to zero anyway, so it's a bit questionable about how useful the global feature importances are.  For the raw explanation, the transformations are applied on the global feature importances, which explains why the issue is on both raw and engineered explanations for global importance values.  If the raw case aggregated the local importance values instead the issue would not appear, but that would also be incorrect since we now may not have all local importance values available on the explanation.