### PR TITLE
release v0.10.0

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -8,8 +8,8 @@ import os
 import shutil
 
 _major = '0'
-_minor = '9'
-_patch = '2'
+_minor = '10'
+_patch = '0'
 
 README_FILE = 'README.md'
 LICENSE_FILE = 'LICENSE.txt'


### PR DESCRIPTION
- updated interpret-core to 0.1.21
- import ABC from collections.abc instead of collections for Python 3 compatibility
- fixed timeseries error where index column not removed for surrogate model when using reset_teacher on evaluation