### PR TITLE
fix for local importance values in binary classification linear surrogate model on sparse data

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -29,12 +29,21 @@ from pandas import read_csv
 from datasets import retrieve_dataset
 
 
-def create_binary_newsgroups_data():
+def create_binary_sparse_newsgroups_data():
     categories = ['alt.atheism', 'soc.religion.christian']
     newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
     newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
     class_names = ['atheism', 'christian']
-    return newsgroups_train, newsgroups_test, class_names
+    x_train = newsgroups_train.data
+    x_test = newsgroups_test.data
+    y_train = newsgroups_train.target
+    y_validation = newsgroups_test.target
+    from sklearn.feature_extraction.text import HashingVectorizer
+    vectorizer = HashingVectorizer(stop_words='english', alternate_sign=False,
+                                   n_features=2**16)
+    x_train = vectorizer.transform(x_train)
+    x_test = vectorizer.transform(x_test)
+    return x_train, x_test, y_train, y_validation, class_names, vectorizer
 
 
 def create_multiclass_sparse_newsgroups_data():

--- a/test/raw_explain/test_raw_explanation.py
+++ b/test/raw_explain/test_raw_explanation.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from common_utils import create_sklearn_svm_classifier, create_sklearn_random_forest_regressor, \
     create_sklearn_linear_regressor, create_multiclass_sparse_newsgroups_data, \
-    create_sklearn_logistic_regressor
+    create_sklearn_logistic_regressor, create_binary_sparse_newsgroups_data
 from constants import DatasetConstants, owner_email_tools_and_ux
 from datasets import retrieve_dataset
 from sklearn.model_selection import train_test_split
@@ -126,6 +126,24 @@ class TestRawExplanations:
 
     def test_get_local_raw_explanations_sparse_classification(self, mimic_explainer):
         x_train, x_test, y_train, _, classes, _ = create_multiclass_sparse_newsgroups_data()
+        # Fit a linear regression model
+        model = create_sklearn_logistic_regressor(x_train, y_train)
+
+        explainer = mimic_explainer(model, x_train, LinearExplainableModel,
+                                    explainable_model_args={'sparse_data': True}, classes=classes)
+        global_explanation = explainer.explain_global(x_test)
+        assert global_explanation.method == LINEAR_METHOD
+
+        num_engineered_feats = x_train.shape[1]
+        feature_map = np.eye(5, num_engineered_feats)
+        feature_names = [str(i) for i in range(feature_map.shape[0])]
+        raw_names = feature_names[:feature_map.shape[0]]
+        global_raw_explanation = global_explanation.get_raw_explanation([feature_map], raw_feature_names=raw_names)
+        self.validate_global_raw_explanation_classification(global_explanation, global_raw_explanation, feature_map,
+                                                            classes, feature_names, is_sparse=True)
+
+    def test_get_local_raw_explanations_sparse_binary_classification(self, mimic_explainer):
+        x_train, x_test, y_train, _, classes, _ = create_binary_sparse_newsgroups_data()
         # Fit a linear regression model
         model = create_sklearn_logistic_regressor(x_train, y_train)
 

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-# Tests for LIME Explainer
+# Tests for MIMIC Explainer
 import json
 import logging
 import numpy as np


### PR DESCRIPTION
fix for local importance values in binary classification linear surrogate model on sparse data

the local importance values in binary classification case on sparse data need to be a list of [-, +] local importance values even though a regression model is used to compute the importance values