### PR TITLE
fixing PFI explainer error when passing true_labels on kwargs

### DIFF
--- a/python/interpret_community/permutation/permutation_importance.py
+++ b/python/interpret_community/permutation/permutation_importance.py
@@ -45,6 +45,8 @@ try:
 except ImportError:
     module_logger.debug('Could not import torch, required if using a pytorch model')
 
+TRUE_LABELS = 'true_labels'
+
 
 def labels_decorator(explain_func):
     """Decorate PFI explainer to throw better error message if true_labels not passed.
@@ -54,7 +56,8 @@ def labels_decorator(explain_func):
     """
     @wraps(explain_func)
     def explain_func_wrapper(self, evaluation_examples, *args, **kwargs):
-        if not args:
+        # NOTE: true_labels can either be in args or kwargs
+        if not args and TRUE_LABELS not in kwargs:
             raise TypeError("PFI explainer requires true_labels parameter to be passed in for explain_global")
         return explain_func(self, evaluation_examples, *args, **kwargs)
     return explain_func_wrapper

--- a/test/test_pfi_explainer.py
+++ b/test/test_pfi_explainer.py
@@ -101,13 +101,18 @@ class TestPFIExplainer(object):
             .verify_explain_model_transformations_column_transformer_regression(true_labels_required=True)
 
     def test_missing_true_labels(self):
-        x_train, x_test, y_train, _, _, _ = create_cancer_data()
+        x_train, x_test, y_train, y_test, _, _ = create_cancer_data()
         # Fit an SVM model
         model = create_sklearn_svm_classifier(x_train, y_train)
-        pfi_explainer = PFIExplainer(model, is_function=True)
+        pfi_explainer = PFIExplainer(model, is_function=False)
         # Validate we throw nice error message to user when missing true_labels parameter
         with pytest.raises(TypeError):
             pfi_explainer.explain_global(x_test)  # pylint: disable=no-value-for-parameter
+        # Validate passing as args works
+        explanation1 = pfi_explainer.explain_global(x_test, y_test)
+        # Validate passing as kwargs works
+        explanation2 = pfi_explainer.explain_global(x_test, true_labels=y_test)
+        assert explanation1.global_importance_values == explanation2.global_importance_values
 
     @property
     def iris_overall_expected_features(self):


### PR DESCRIPTION
fixing PFI explainer error when passing true_labels on kwargs

follow-up to previous PR, the recently added check makes PFI fail when true_labels is passed on kwargs instead of args