### PR TITLE
Tooltips for charts and bugfixes

### DIFF
--- a/visualization/dashboard/package.json
+++ b/visualization/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "interpret-dashboard",
-  "version": "0.1.9",
+  "version": "0.1.9-beta1",
   "license": "See license file 'LICENSE'",
   "description": "ML Chart Lib",
   "main": "rel/index.js",

--- a/visualization/dashboard/src/Localization/en.json
+++ b/visualization/dashboard/src/Localization/en.json
@@ -234,7 +234,9 @@
         "falsePositive": "False positive",
         "falseNegative": "False negative",
         "dataset": "Dataset",
-        "predictedProbabilities": "Prediction probabilities"
+        "predictedProbabilities": "Prediction probabilities",
+        "none": "Count",
+        "_none.comment": "option to not have data on this axis, instead just counts number of points" 
     },
     "WhatIf": {
         "closeAriaLabel": "Close",
@@ -312,7 +314,17 @@
         "numberOfDatapoints": "Number of datapoints",
         "_numberOfDatapoints.comment": "some charts will always show the count of the number of rows in a group, this is the axis label on the chart",
         "xValue": "X-value",
-        "_xValue.comment":"label for x value button on chart"
+        "_xValue.comment":"label for x value button on chart",
+        "rowIndex": "Row index",
+        "_rowIndex.comment": "the index of a row in a dataset",
+        "featureImportance": "Feature importance",
+        "countTooltipPrefix": "Count: {0}",
+        "_countTooltipPrefix.comment": "on hover, show the prefix followed by the total number of points",
+        "featurePrefix": "Feature",
+        "_featurePrefix.comment": "label shown before feature name in tooltip",
+        "importancePrefix": "Importance",
+        "_importance.comment": "label shown before importance value in tooltip",
+        "cohort": "Cohort"
     },
     "DatasetExplorer": {
         "helperText": "Learn about the over/underpresentation in your dataset. Create dataset cohorts above to analyze statistics along filters such as predicted outcome, dataset features and error groups. Use the x-axis and color selectors to further slice your dataset into more dimensions. Use the gear icon in the graph to change graph types.",
@@ -326,7 +338,9 @@
         "chartType": "Chart type",
         "_chartType.comment": "label for dropdown to select chart format",
         "missingParameters": "This tab requires an evaluation dataset be supplied.",
-        "_missingPArameters.comment": "Show a message if the required dataset parameter is not provided"
+        "_missingPArameters.comment": "Show a message if the required dataset parameter is not provided",
+        "noColor": "None",
+        "_noColor.comment": "placeholder text when no color axis picked"
     },
     "DependencePlot": {
         "featureImportanceOf": "Feature importance of",
@@ -355,7 +369,7 @@
         "_showLabel.comment": "label on button to pick what additional chart to show",
         "featureImportancePlot": "Feature importance plot",
         "_featureImportancePlot.comment": "name of a plot type showing the importance of each feature in making a decision",
-        "icePlot": "ICE plot",
+        "icePlot": "Individual conditional expectation (ICE) plot",
         "_icePlot.comment": "name of a plot type named Individual Conditional Expectation (ICE)",
         "featureImportanceLackingParameters": "Provide local feature importances to see how each feature impacts individual predictions.",
         "_featureImportanceLackingParameters.comment": "placeholder if no local feature importances passed in",
@@ -457,7 +471,8 @@
         "groupByCohort": "Group by cohort",
         "_groupByCohort.comment": "if user selects to group by cohort, no further parameters to set, just show a message to fill space",
         "selectClass": "Select class",
-        "_selectClass.comment": "label for dropdown listing all classes"
+        "_selectClass.comment": "label for dropdown listing all classes",
+        "countHelperText": "A histogram of the number of points"
     },
     "ValidationErrors": {
         "predictedProbability": "Predicted probability",

--- a/visualization/dashboard/src/MLIDashboard/Cohort.ts
+++ b/visualization/dashboard/src/MLIDashboard/Cohort.ts
@@ -7,9 +7,9 @@ export class Cohort {
     private static _cohortIndex: number = 0;
 
     public rowCount: number = 0;
+    public filteredData: Array<{[key: string]: number}>;
     private readonly cohortIndex: number;
     private mutateCount: number = 0;
-    private filteredData: Array<{[key: string]: number}>;
     private cachedAverageImportance: number[];
     private cachedTransposedLocalFeatureImportances: number[][];
     private currentSortKey: string | undefined;

--- a/visualization/dashboard/src/MLIDashboard/Controls/AxisConfigurationDialog/AxisConfigDialog.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/AxisConfigurationDialog/AxisConfigDialog.tsx
@@ -40,7 +40,7 @@ export class AxisConfigDialog extends React.PureComponent<IAxisConfigProps, IAxi
     private static readonly MAX_HIST_COLS = 40;
     private static readonly DEFAULT_BIN_COUNT = 5;
 
-    private readonly leftItems= [
+    private readonly leftItems = [
         Cohort.CohortKey,
         JointDataset.IndexLabel,
         JointDataset.DataLabelRoot,
@@ -48,7 +48,8 @@ export class AxisConfigDialog extends React.PureComponent<IAxisConfigProps, IAxi
         JointDataset.TrueYLabel,
         JointDataset.ClassificationError,
         JointDataset.RegressionError,
-        JointDataset.ProbabilityYRoot
+        JointDataset.ProbabilityYRoot,
+        ColumnCategories.none
     ].map(key => {
         const metaVal = this.props.jointDataset.metaDict[key];
         if (key === JointDataset.DataLabelRoot &&
@@ -129,7 +130,12 @@ export class AxisConfigDialog extends React.PureComponent<IAxisConfigProps, IAxi
                                 <Text>{localization.AxisConfigDialog.groupByCohort}</Text>
                             </div>
                     )}
-                    {this.state.selectedColumn.property !== Cohort.CohortKey &&
+                     {this.state.selectedColumn.property === ColumnCategories.none && (
+                        <div className={styles.rightHalf}>
+                                <Text>{localization.AxisConfigDialog.countHelperText}</Text>
+                        </div>
+                    )}
+                    {(this.state.selectedColumn.property !== Cohort.CohortKey && this.state.selectedColumn.property !== ColumnCategories.none) &&
                     (<div className={styles.rightHalf}>
                         {isDataColumn && (
                             <ComboBox
@@ -211,6 +217,9 @@ export class AxisConfigDialog extends React.PureComponent<IAxisConfigProps, IAxi
     }
 
     private extractSelectionKey(key: string): string {
+        if (key === undefined) {
+            return ColumnCategories.none;
+        }
         if (key.indexOf(JointDataset.DataLabelRoot) !== -1) {
             return JointDataset.DataLabelRoot;
         }
@@ -300,6 +309,15 @@ export class AxisConfigDialog extends React.PureComponent<IAxisConfigProps, IAxi
             return;
         }
         let property = this._leftSelection.getSelection()[0].key as string;
+        if (property === ColumnCategories.none) {
+            this.setState({selectedColumn: {
+                property,
+                options: {
+                    dither: false
+                }
+            }, binCount: undefined});
+            return;
+        }
         if (property === JointDataset.DataLabelRoot || property === JointDataset.ProbabilityYRoot) {
             property += "0";
         }

--- a/visualization/dashboard/src/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.styles.ts
+++ b/visualization/dashboard/src/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.styles.ts
@@ -28,6 +28,7 @@ export interface IDatasetExplorerTabStyles {
     missingParametersPlaceholder: IStyle;
     missingParametersPlaceholderSpacer: IStyle;
     faintText: IStyle;
+    smallItalic: IStyle;
 }
 
 export const dastasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplorerTabStyles> = () => {
@@ -167,6 +168,7 @@ export const dastasetExplorerTabStyles: () => IProcessedStyleSet<IDatasetExplore
         },
         missingParametersPlaceholder: [FabricStyles.missingParameterPlaceholder],
         missingParametersPlaceholderSpacer: [FabricStyles.missingParameterPlaceholderSpacer],
-        faintText: [FabricStyles.faintText]
+        faintText: [FabricStyles.faintText],
+        smallItalic: [FabricStyles.placeholderItalic]
     });
 };

--- a/visualization/dashboard/src/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
@@ -136,6 +136,10 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
         const legend = this.buildColorLegend(classNames);
         const cohortLength = this.props.cohorts[this.state.selectedCohortIndex].rowCount;
         const canRenderChart = cohortLength < NewExplanationDashboard.ROW_ERROR_SIZE || this.props.chartProps.chartType !== ChartTypes.Scatter;
+        const yAxisCategories = [ColumnCategories.index, ColumnCategories.dataset, ColumnCategories.outcome];
+        if (this.props.chartProps.chartType !== ChartTypes.Scatter) {
+            yAxisCategories.push(ColumnCategories.none);
+        }
         const isHistogram = this.props.chartProps.chartType !== ChartTypes.Scatter && (
             this.props.chartProps.yAxis === undefined ||
             this.props.jointDataset.metaDict[this.props.chartProps.yAxis.property].treatAsCategorical);
@@ -172,7 +176,7 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                                     {(this.state.yDialogOpen) && (
                                         <AxisConfigDialog 
                                             jointDataset={this.props.jointDataset}
-                                            orderedGroupTitles={[ColumnCategories.index, ColumnCategories.dataset, ColumnCategories.outcome]}
+                                            orderedGroupTitles={yAxisCategories}
                                             selectedColumn={this.props.chartProps.yAxis}
                                             canBin={false}
                                             mustBin={false}
@@ -280,6 +284,9 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
     private onChartTypeChange(event: React.SyntheticEvent<HTMLElement>, item: IChoiceGroupOption): void {
         const newProps = _.cloneDeep(this.props.chartProps);
         newProps.chartType = item.key as ChartTypes;
+        if (newProps.yAxis.property === ColumnCategories.none) {
+            newProps.yAxis = this.generateDefaultYAxis();
+        }
         this.props.onChange(newProps);
     }
 
@@ -344,11 +351,14 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                 colorAxis.options.bin || this.props.jointDataset.metaDict[colorAxis.property].treatAsCategorical)) {
                     this.props.cohorts[this.state.selectedCohortIndex].sort(colorAxis.property)
                     const includedIndexes = _.uniq(this.props.cohorts[this.state.selectedCohortIndex].unwrap(colorAxis.property, true));
-                    colorSeries = includedIndexes.map(category => this.props.jointDataset.metaDict[colorAxis.property].sortedCategoricalValues[category]);
+                    colorSeries = this.props.jointDataset.metaDict[colorAxis.property].sortedCategoricalValues;
+            } else {
+                // continuous color, handled by plotly for now
+                return;
             }
         } else {
             const colorAxis = this.props.chartProps.yAxis;
-            if (this.props.jointDataset.metaDict[colorAxis.property].treatAsCategorical) {
+            if (this.props.jointDataset.metaDict[colorAxis.property].treatAsCategorical && colorAxis.property !== ColumnCategories.none) {
                 this.props.cohorts[this.state.selectedCohortIndex].sort(colorAxis.property)
                 const includedIndexes = _.uniq(this.props.cohorts[this.state.selectedCohortIndex].unwrap(colorAxis.property));
                 colorSeries = includedIndexes.map(category => this.props.jointDataset.metaDict[colorAxis.property].sortedCategoricalValues[category]);
@@ -364,6 +374,9 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                     <Text nowrap variant={"medium"} className={classNames.legendLabel}>{name}</Text>
                 </div>)
             })}
+            {colorSeries.length === 0 && (
+                <Text variant={"xSmall"} className={classNames.smallItalic}>{localization.DatasetExplorer.noColor}</Text>
+            )}
         </div>)
     }
 
@@ -481,7 +494,7 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                         ]
                     }
                 ];
-                if (chartProps.yAxis) {
+                if (chartProps.yAxis && chartProps.yAxis.property !== ColumnCategories.none) {
                     const rawColor = cohort.unwrap(chartProps.yAxis.property, true);
                     const styles = jointData.metaDict[chartProps.yAxis.property].sortedCategoricalValues.map((label, index) => {
                         return {
@@ -505,33 +518,42 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
             }
         }
         plotlyProps.data[0].customdata = this.buildCustomData(jointData, chartProps, cohort);
-        plotlyProps.data[0].hovertemplate = this.buildHoverTemplate(chartProps);
+        plotlyProps.data[0].hovertemplate = this.buildHoverTemplate(jointData, chartProps);
         return plotlyProps;
     }
 
-    private static buildHoverTemplate(chartProps: IGenericChartProps): string {
+    private static buildHoverTemplate(jointData: JointDataset, chartProps: IGenericChartProps): string {
         let hovertemplate = "";
+        const xName = jointData.metaDict[chartProps.xAxis.property].abbridgedLabel;
+        const yName = jointData.metaDict[chartProps.yAxis.property].abbridgedLabel;
         switch(chartProps.chartType) {
             case ChartTypes.Scatter: {
                 if (chartProps.xAxis) {
                     if (chartProps.xAxis.options.dither) {
-                        hovertemplate += "x: %{customdata.X}<br>";
+                        hovertemplate += xName + ": %{customdata.X}<br>";
                     } else {
-                        hovertemplate += "x: %{x}<br>";
+                        hovertemplate += xName + ": %{x}<br>";
                     }
                 }
                 if (chartProps.yAxis) {
                     if (chartProps.yAxis.options.dither) {
-                        hovertemplate += "y: %{customdata.Y}<br>";
+                        hovertemplate += yName + ": %{customdata.Y}<br>";
                     } else {
-                        hovertemplate += "y: %{y}<br>";
+                        hovertemplate += yName + ": %{y}<br>";
                     }
                 }
+                if (chartProps.colorAxis) {
+                    hovertemplate += jointData.metaDict[chartProps.colorAxis.property].abbridgedLabel + ": %{customdata.Color}<br>";
+                }
+                hovertemplate += localization.Charts.rowIndex + ": %{customdata.AbsoluteIndex}<br>";
                 break;
             }
             case ChartTypes.Histogram: {
-                hovertemplate += "x: %{text}<br>";
-                hovertemplate += "count: %{y}<br>";
+                hovertemplate += xName + ": %{text}<br>";
+                if (chartProps.yAxis.property !== ColumnCategories.none && jointData.metaDict[chartProps.yAxis.property].isCategorical) {
+                    hovertemplate += yName + ": %{customdata.Y}<br>";
+                }
+                hovertemplate += localization.formatString(localization.Charts.countTooltipPrefix, "%{y}<br>");
             }
         }
         hovertemplate += "<extra></extra>";
@@ -554,7 +576,7 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                         customdata[index]["X"] = jointData.metaDict[chartProps.xAxis.property]
                             .sortedCategoricalValues[val];
                     } else {
-                        customdata[index]["X"] = val;
+                        customdata[index]["X"] = (val as number).toLocaleString(undefined, {maximumFractionDigits: 3});
                     }
                 });
             }
@@ -567,8 +589,34 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
                         customdata[index]["Y"] = jointData.metaDict[chartProps.yAxis.property]
                             .sortedCategoricalValues[val];
                     } else {
-                        customdata[index]["Y"] = val;
+                        customdata[index]["Y"] = (val as number).toLocaleString(undefined, {maximumFractionDigits: 3});
                     }
+                });
+            }
+            const colorAxis = chartProps.colorAxis;
+            if (colorAxis && colorAxis.property) {
+                const rawColor = cohort.unwrap(chartProps.colorAxis.property);
+                rawColor.forEach((val, index) => {
+                    if (jointData.metaDict[colorAxis.property].treatAsCategorical) {
+                        customdata[index]["Color"] = jointData.metaDict[colorAxis.property]
+                            .sortedCategoricalValues[val];
+                    } else {
+                        customdata[index]["Color"] = val.toLocaleString(undefined, {maximumFractionDigits: 3});
+                    }
+                });
+            }
+            const indices = cohort.unwrap(JointDataset.IndexLabel, false);
+            indices.forEach((absoluteIndex, i) => {
+                customdata[i]["AbsoluteIndex"] = absoluteIndex;
+            });
+        }
+        if (chartProps.chartType === ChartTypes.Histogram &&
+            chartProps.yAxis.property !== ColumnCategories.none) {
+            const yMeta = jointData.metaDict[chartProps.yAxis.property];
+            if (yMeta.isCategorical) {
+                const rawY = cohort.unwrap(chartProps.yAxis.property);
+                rawY.forEach((val, index) => {
+                    customdata[index]["Y"] = yMeta.sortedCategoricalValues[val];
                 });
             }
         }
@@ -576,23 +624,13 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
     }
 
     private generateDefaultChartAxes(): void {
-        let maxIndex: number = 0;
-        let maxVal: number = Number.MIN_SAFE_INTEGER;
-        const yKey = JointDataset.DataLabelRoot + maxIndex.toString();
-        const yIsDithered = this.props.jointDataset.metaDict[yKey].isCategorical;
         const chartProps: IGenericChartProps = {
             chartType: ChartTypes.Histogram,
             xAxis: {
                 property: JointDataset.IndexLabel,
                 options: {}
             },
-            yAxis: {
-                property: yKey,
-                options: {
-                    dither: yIsDithered,
-                    bin: false
-                }
-            },
+            yAxis: this.generateDefaultYAxis(),
             colorAxis: {
                 property: this.props.jointDataset.hasPredictedY ?
                     JointDataset.PredictedYLabel : JointDataset.IndexLabel,
@@ -602,6 +640,18 @@ export class DatasetExplorerTab extends React.PureComponent<IDatasetExplorerTabP
         this.props.onChange(chartProps);
     }
 
+    private generateDefaultYAxis(): ISelectorConfig {
+        const yKey = JointDataset.DataLabelRoot + "0";
+        const yIsDithered = this.props.jointDataset.metaDict[yKey].isCategorical;
+        return {
+            property: yKey,
+            options: {
+                dither: yIsDithered,
+                bin: false
+            }
+        };
+    }
+    
     private scatterSelection(guid: string, selections: string[], plotlyProps: IPlotlyProperty): void {
         const selectedPoints =
             selections.length === 0

--- a/visualization/dashboard/src/MLIDashboard/Controls/DependencePlot/DependencePlot.styles.ts
+++ b/visualization/dashboard/src/MLIDashboard/Controls/DependencePlot/DependencePlot.styles.ts
@@ -73,7 +73,7 @@ export const dependencePlotStyles: () => IProcessedStyleSet<IDependencePlotStyle
         },
         secondaryChartPlacolderBox: {
             height: "400px",
-            width: "100%"
+            flex: 1
         },
         secondaryChartPlacolderSpacer: {
             margin: "25px auto 0 auto",

--- a/visualization/dashboard/src/MLIDashboard/Controls/DependencePlot/DependencePlot.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/DependencePlot/DependencePlot.tsx
@@ -154,10 +154,11 @@ export class DependencePlot extends React.PureComponent<IDependecePlotProps> {
                 _.set(plotlyProps, "layout.xaxis.tickvals", xLabelIndexes);
             }
             const rawX = cohort.unwrap(this.props.chartProps.xAxis.property);
+            const xLabel = jointData.metaDict[this.props.chartProps.xAxis.property].label;
             if (this.props.chartProps.xAxis.options.dither) {
                 const dithered = cohort.unwrap(JointDataset.DitherLabel);
                 plotlyProps.data[0].x = dithered.map((dither, index) => { return rawX[index] + dither;});
-                hovertemplate += "x: %{customdata.X}<br>";
+                hovertemplate += xLabel + ": %{customdata.X}<br>";
                 rawX.forEach((val, index) => {
                     // If categorical, show string value in tooltip
                     if (jointData.metaDict[this.props.chartProps.xAxis.property].isCategorical) {
@@ -169,7 +170,7 @@ export class DependencePlot extends React.PureComponent<IDependecePlotProps> {
                 });
             } else {
                 plotlyProps.data[0].x = rawX;
-                hovertemplate += "x: %{x}<br>";
+                hovertemplate += xLabel + ": %{x}<br>";
             }
         }
         if (this.props.chartProps.yAxis) {
@@ -179,54 +180,20 @@ export class DependencePlot extends React.PureComponent<IDependecePlotProps> {
                 _.set(plotlyProps, "layout.yaxis.ticktext", yLabels);
                 _.set(plotlyProps, "layout.yaxis.tickvals", yLabelIndexes);
             }
-            const rawY = cohort.unwrap(this.props.chartProps.yAxis.property);
-            if (this.props.chartProps.yAxis.options.dither) {
-                const dithered = cohort.unwrap(JointDataset.DitherLabel);
-                plotlyProps.data[0].y = dithered.map((dither, index) => { return rawY[index] + dither;});
-                hovertemplate += "y: %{customdata.Y}<br>";
-                rawY.forEach((val, index) => {
-                    // If categorical, show string value in tooltip
-                    if (jointData.metaDict[this.props.chartProps.yAxis.property].isCategorical) {
-                        customdata[index]["Y"] = jointData.metaDict[this.props.chartProps.yAxis.property].sortedCategoricalValues[val];
-                    } else {
-                        customdata[index]["Y"] = val;
-                    }
-                });
-            } else {
-                plotlyProps.data[0].y = rawY;
-                hovertemplate += "y: %{y}<br>";
-            }
+            const rawY: number[] = cohort.unwrap(this.props.chartProps.yAxis.property);
+            const yLabel = localization.Charts.featureImportance;
+            plotlyProps.data[0].y = rawY;
+            rawY.forEach((val, index) => {
+                customdata[index]["Yformatted"] = val.toLocaleString(undefined, {maximumFractionDigits: 3});
+            })
+            hovertemplate += yLabel + ": %{customdata.Yformatted}<br>";
+            
         }
-        if (this.props.chartProps.colorAxis) {
-            const isBinned = this.props.chartProps.colorAxis.options && this.props.chartProps.colorAxis.options.bin;
-            const rawColor = cohort.unwrap(this.props.chartProps.colorAxis.property, isBinned);
-            // handle binning to categories later
-            if (jointData.metaDict[this.props.chartProps.colorAxis.property].isCategorical || isBinned) {
-                const styles = jointData.metaDict[this.props.chartProps.colorAxis.property].sortedCategoricalValues.map((label, index) => {
-                    return {
-                        target: index,
-                        value: { name: label}
-                    };
-                });
-                plotlyProps.data[0].transforms = [{
-                    type: "groupby",
-                    groups: rawColor,
-                    styles
-                }];
-                plotlyProps.layout.showlegend = true;
-            } else {
-                plotlyProps.data[0].marker = {
-                    color: rawColor,
-                    colorbar: {
-                        title: {
-                            side: "right",
-                            text: "placeholder"
-                        } as any
-                    },
-                    colorscale: "Bluered"
-                };
-            }
-        }
+        const indecies = cohort.unwrap(JointDataset.IndexLabel, false);
+        indecies.forEach((absoluteIndex, i) => {
+            customdata[i]["AbsoluteIndex"] = absoluteIndex;
+        });
+        hovertemplate += localization.Charts.rowIndex + ": %{customdata.AbsoluteIndex}<br>";
         hovertemplate += "<extra></extra>";
         plotlyProps.data[0].customdata = customdata as any;
         plotlyProps.data[0].hovertemplate = hovertemplate;

--- a/visualization/dashboard/src/MLIDashboard/Controls/FeatureImportanceBar/FeatureImportanceBar.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/FeatureImportanceBar/FeatureImportanceBar.tsx
@@ -127,21 +127,39 @@ export class FeatureImportanceBar extends React.PureComponent<IFeatureBarProps, 
             } as any
         };
 
+        const xText = sortedIndexVector.map(i =>this.props.unsortedX[i]);
         if (this.props.chartType === ChartTypes.Bar) {
             baseSeries.layout.barmode = 'group';
+            let hovertemplate = this.props.unsortedSeries[0].unsortedFeatureValues ?
+                "%{text}: %{customdata.Yvalue}<br>" :
+                localization.Charts.featurePrefix + ": %{text}<br>";
+            hovertemplate += localization.Charts.importancePrefix + ": %{customdata.Yformatted}<br>";
+            hovertemplate += "%{customdata.Name}<br>";
+            hovertemplate += "<extra></extra>";
+
             const x = sortedIndexVector.map((unused, index) => index);
 
             this.props.unsortedSeries.forEach((series, seriesIndex) => {
                 baseSeries.data.push({
+                    hoverinfo: 'all',
                     orientation: 'v',
                     type: 'bar',
                     name: series.name,
+                    customdata: sortedIndexVector.map(index => {
+                        return {
+                           "Name": series.name, 
+                           "Yformatted": series.unsortedAggregateY[index].toLocaleString(undefined, {maximumFractionDigits: 3}),
+                           "Yvalue": series.unsortedFeatureValues ? series.unsortedFeatureValues[index] : undefined
+                       };
+                   }),
+                   text: xText,
                     x,
                     y: sortedIndexVector.map(index => series.unsortedAggregateY[index]),
                     marker: {
                         color: sortedIndexVector.map(index => (index === this.props.selectedFeatureIndex && seriesIndex === this.props.selectedSeriesIndex) ?
                             FabricStyles.fabricColorPalette[series.colorIndex] : FabricStyles.fabricColorPalette[series.colorIndex])
-                    }
+                    },
+                    hovertemplate
                 } as any);
                 
             });
@@ -172,13 +190,9 @@ export class FeatureImportanceBar extends React.PureComponent<IFeatureBarProps, 
             });
         }
 
-
-        
-
-        const ticktext = sortedIndexVector.map(i =>this.props.unsortedX[i]);
         const tickvals = sortedIndexVector.map((val, index) => index);
 
-        _.set(baseSeries, 'layout.xaxis.ticktext', ticktext);
+        _.set(baseSeries, 'layout.xaxis.ticktext', xText);
         _.set(baseSeries, 'layout.xaxis.tickvals', tickvals);
         return baseSeries;
     }

--- a/visualization/dashboard/src/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.tsx
@@ -100,8 +100,7 @@ export class ModelPerformanceTab extends React.PureComponent<IModelPerformanceTa
                             <div className={classNames.rotatedVerticalBox}>
                                 <div>
                                     <Text block variant="mediumPlus" className={classNames.boldText}>{
-                                        this.props.chartProps.chartType === ChartTypes.Histogram ?
-                                        localization.Charts.numberOfDatapoints : localization.Charts.yValue}</Text>
+                                        localization.Charts.yValue}</Text>
                                     <DefaultButton 
                                         onClick={this.setYOpen.bind(this, true)}
                                         id={this._yButtonId}
@@ -143,7 +142,7 @@ export class ModelPerformanceTab extends React.PureComponent<IModelPerformanceTa
                                     {this.props.jointDataset.hasTrueY && metricsList.map(stats => {
                                         return (<div className={classNames.statsBox}>
                                             {stats.map(labeledStat => {
-                                                return <Text block >{localization.formatString(labeledStat.label, labeledStat.stat.toPrecision(3))}</Text>;
+                                                return <Text block >{localization.formatString(labeledStat.label, labeledStat.stat.toLocaleString(undefined, {maximumFractionDigits: 3}))}</Text>;
                                             })}
                                         </div>)
                                     })}
@@ -155,7 +154,9 @@ export class ModelPerformanceTab extends React.PureComponent<IModelPerformanceTa
                         <div className={classNames.paddingDiv}></div>
                         <div className={classNames.horizontalAxis}>
                             <div>
-                                <Text block variant="mediumPlus" className={classNames.boldText}>{localization.Charts.xValue}</Text>
+                                <Text block variant="mediumPlus" className={classNames.boldText}>{
+                                    this.props.chartProps.chartType === ChartTypes.Histogram ?
+                                    localization.Charts.numberOfDatapoints : localization.Charts.xValue}</Text>
                                 <DefaultButton 
                                     onClick={this.setXOpen.bind(this, true)}
                                     id={this._xButtonId}

--- a/visualization/dashboard/src/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/visualization/dashboard/src/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -238,14 +238,11 @@ export const whatIfTabStyles: () => IProcessedStyleSet<IWhatIfTabStyles> = () =>
             alignItems: "baseline"
         },
         choiceGroup: {
-            fontSize: "14px",
-            paddingLeft: "30px",
-            width: "230px",
-
+            paddingLeft: "30px"
         },
         choiceGroupFlexContainer: {
             display: "inline-flex",
-            width: "300px",
+            width: "500px",
             justifyContent: "space-between"
         },
         panelIconAndLabel: {

--- a/visualization/dashboard/src/MLIDashboard/Controls/WhatIfTab/WhatIfTab.tsx
+++ b/visualization/dashboard/src/MLIDashboard/Controls/WhatIfTab/WhatIfTab.tsx
@@ -1,6 +1,6 @@
 import { IProcessedStyleSet, getTheme } from "@uifabric/styling";
 import _ from "lodash";
-import { AccessibleChart, IPlotlyProperty, PlotlyMode } from "mlchartlib";
+import { AccessibleChart, IPlotlyProperty, PlotlyMode, IData } from "mlchartlib";
 import { ChoiceGroup, IChoiceGroupOption, Icon, Slider, Text, ComboBox, IComboBox  } from "office-ui-fabric-react";
 import { DefaultButton, IconButton, PrimaryButton } from "office-ui-fabric-react/lib/Button";
 import { Dropdown, IDropdownOption } from "office-ui-fabric-react/lib/Dropdown";
@@ -113,6 +113,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
     private testableDatapoints: any[][] = [];
     private temporaryPoint: { [key: string]: any };
     private testableDatapointColors: string[] = FabricStyles.fabricColorPalette;
+    private testableDatapointNames: string[] = [];
     private featuresOption: IDropdownOption[] = new Array(this.props.jointDataset.datasetFeatureCount).fill(0)
         .map((unused, index) => {
         const key = JointDataset.DataLabelRoot + index.toString();
@@ -212,6 +213,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                 }
             }).filter(item => !!item);
             const includedColors = this.includedFeatureImportance.map(item => FabricStyles.fabricColorPalette[item.colorIndex]);
+            const includedNames = this.includedFeatureImportance.map(item => item.name);
             const includedRows = this.state.pointIsActive.map((isActive, i) => {
                 if (isActive) {
                     return this.selectedDatapoints[i];
@@ -220,11 +222,14 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
             const includedCustomRows = this.state.customPointIsActive.map((isActive, i) => {
                 if (isActive) {
                     includedColors.push(FabricStyles.fabricColorPalette[WhatIfTab.MAX_SELECTION + i + 1])
+                    includedColors.push(FabricStyles.fabricColorPalette[WhatIfTab.MAX_SELECTION + i + 1]);
+                    includedNames.push(this.state.customPoints[i][WhatIfTab.namePath]);
                     return this.customDatapoints[i];
                 }
             }).filter(item => !!item);
             this.testableDatapoints = [...includedRows, ...includedCustomRows];
             this.testableDatapointColors = includedColors;
+            this.testableDatapointNames = includedNames;
             this.forceUpdate();
         }
         this.setState({ sortingSeriesIndex, sortArray })
@@ -562,6 +567,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                             invokeModel={this.props.invokeModel}
                             datapoints={this.testableDatapoints}
                             colors={this.testableDatapointColors}
+                            rowNames={this.testableDatapointNames}
                             jointDataset={this.props.jointDataset}
                             metadata={this.props.metadata}
                             feature={this.state.selectedFeatureKey}
@@ -620,7 +626,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                     {predictedClass !== undefined &&
                     (<Text block variant="small">{localization.formatString(localization.WhatIfTab.predictedClass, predictedClassName)}</Text>)}
                     {predictedProb !== undefined &&
-                    (<Text block variant="small">{localization.formatString(localization.WhatIfTab.probability, predictedProb.toPrecision(3))}</Text>)}
+                    (<Text block variant="small">{localization.formatString(localization.WhatIfTab.probability, predictedProb.toLocaleString(undefined, {maximumFractionDigits: 3}))}</Text>)}
                 </div>);
         } else {
             const row = this.props.jointDataset.getRow(this.state.selectedWhatIfRootIndex);
@@ -632,7 +638,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                 {trueValue !== undefined && 
                     (<Text block variant="small">{localization.formatString(localization.WhatIfTab.trueValue, trueValue)}</Text>)}
                 {predictedValue !== undefined &&
-                    (<Text block variant="small">{localization.formatString(localization.WhatIfTab.predictedValue, predictedValue.toPrecision(3))}</Text>)}
+                    (<Text block variant="small">{localization.formatString(localization.WhatIfTab.predictedValue, predictedValue.toLocaleString(undefined, {maximumFractionDigits: 3}))}</Text>)}
             </div>);
     }
     }
@@ -653,7 +659,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                     {this.props.jointDataset.hasPredictedY && predictedClass === undefined &&
                     (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newPredictedClass, localization.WhatIfTab.loading)}</Text>)}
                     {this.props.jointDataset.hasPredictedProbabilities && predictedProb !== undefined &&
-                    (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newProbability, predictedProb.toPrecision(3))}</Text>)}
+                    (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newProbability, predictedProb.toLocaleString(undefined, {maximumFractionDigits: 3}))}</Text>)}
                     {this.props.jointDataset.hasPredictedProbabilities && predictedProb === undefined &&
                     (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newProbability, localization.WhatIfTab.loading)}</Text>)}
                 </div>);
@@ -662,7 +668,7 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                 this.temporaryPoint[JointDataset.PredictedYLabel] : undefined;
             return (<div className={classNames.customPredictBlock}>
                 {this.props.jointDataset.hasPredictedY && predictedValue !== undefined &&
-                (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newPredictedValue, predictedValue.toPrecision(3))}</Text>)}
+                (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newPredictedValue, predictedValue.toLocaleString(undefined, {maximumFractionDigits: 3}))}</Text>)}
                 {this.props.jointDataset.hasPredictedY && predictedValue === undefined &&
                 (<Text block variant="small" className={classNames.boldText}>{localization.formatString(localization.WhatIfTab.newPredictedValue, localization.WhatIfTab.loading)}</Text>)}
             </div>);
@@ -727,7 +733,9 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
         this.setState(prevState => {
             const customPoints = [...prevState.customPoints];
             customPoints.splice(index, 1);
-            return { customPoints };
+            const customPointIsActive = [...prevState.customPointIsActive];
+            customPointIsActive.splice(index, 1);
+            return { customPoints, customPointIsActive };
         });
     }
 
@@ -969,21 +977,6 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                 _.set(plotlyProps, "layout.xaxis.ticktext", xLabels);
                 _.set(plotlyProps, "layout.xaxis.tickvals", xLabelIndexes);
             }
-            const rawX = cohort.unwrap(chartProps.xAxis.property);
-            const customX = JointDataset.unwrap(this.state.customPoints, chartProps.xAxis.property);
-            const tempX = JointDataset.unwrap([this.temporaryPoint], chartProps.xAxis.property);
-            if (chartProps.xAxis.options.dither) {
-                const dithered = cohort.unwrap(JointDataset.DitherLabel);
-                const customDithered = JointDataset.unwrap(this.state.customPoints, JointDataset.DitherLabel);
-                const tempDithered = JointDataset.unwrap([this.temporaryPoint], JointDataset.DitherLabel);
-                plotlyProps.data[0].x = dithered.map((dither, index) => { return rawX[index] + dither; });
-                plotlyProps.data[1].x = customDithered.map((dither, index) => { return customX[index] + dither; });
-                plotlyProps.data[2].x = tempDithered.map((dither, index) => { return tempX[index] + dither; })
-            } else {
-                plotlyProps.data[0].x = rawX;
-                plotlyProps.data[1].x = customX;
-                plotlyProps.data[2].x = tempX;
-            }
         }
         if (chartProps.yAxis) {
             if (jointData.metaDict[chartProps.yAxis.property].isCategorical) {
@@ -992,84 +985,64 @@ export class WhatIfTab extends React.PureComponent<IWhatIfTabProps, IWhatIfTabSt
                 _.set(plotlyProps, "layout.yaxis.ticktext", yLabels);
                 _.set(plotlyProps, "layout.yaxis.tickvals", yLabelIndexes);
             }
-            const rawY = cohort.unwrap(chartProps.yAxis.property);
-            const customY = JointDataset.unwrap(this.state.customPoints, chartProps.yAxis.property);
-            const tempY = JointDataset.unwrap([this.temporaryPoint], chartProps.yAxis.property);
-            if (chartProps.yAxis.options.dither) {
-                const dithered = cohort.unwrap(JointDataset.DitherLabel);
-                const customDithered = JointDataset.unwrap(this.state.customPoints, JointDataset.DitherLabel);
-                const tempDithered = JointDataset.unwrap([this.temporaryPoint], JointDataset.DitherLabel);
-                plotlyProps.data[0].y = dithered.map((dither, index) => { return rawY[index] + dither; });
-                plotlyProps.data[1].y = customDithered.map((dither, index) => { return customY[index] + dither; });
-                plotlyProps.data[2].y = tempDithered.map((dither, index) => { return tempY[index] + dither; })
-            } else {
-                plotlyProps.data[0].y = rawY;
-                plotlyProps.data[1].y = customY;
-                plotlyProps.data[2].y = tempY;
-            }
         }
 
 
-        plotlyProps.data[0].customdata = WhatIfTab.buildCustomData(jointData, chartProps, cohort);
-        plotlyProps.data[0].hovertemplate = WhatIfTab.buildHoverTemplate(chartProps);
+        this.generateDataTrace(cohort.filteredData, chartProps, plotlyProps.data[0]);
+        this.generateDataTrace(this.state.customPoints, chartProps, plotlyProps.data[1]);
+        this.generateDataTrace([this.temporaryPoint], chartProps, plotlyProps.data[2]);
         return plotlyProps;
     }
 
-    private static buildHoverTemplate(chartProps: IGenericChartProps): string {
-        let hovertemplate = "";
-        if (chartProps.xAxis) {
-            if (chartProps.xAxis.options.dither) {
-                hovertemplate += "x: %{customdata.X}<br>";
-            } else {
-                hovertemplate += "x: %{x}<br>";
-            }
-        }
-        if (chartProps.yAxis) {
-            if (chartProps.yAxis.options.dither) {
-                hovertemplate += "y: %{customdata.Y}<br>";
-            } else {
-                hovertemplate += "y: %{y}<br>";
-            }
-        }
-        hovertemplate += "<extra></extra>";
-        return hovertemplate;
-    }
-
-    private static buildCustomData(jointData: JointDataset, chartProps: IGenericChartProps, cohort: Cohort): Array<any> {
-        const customdata = cohort.unwrap(JointDataset.IndexLabel).map(val => {
+    private generateDataTrace(dictionary: Array<{[key: string]: number}>, chartProps: IGenericChartProps, trace: IData): void {
+        const customdata = JointDataset.unwrap(dictionary, JointDataset.IndexLabel).map(val => {
             const dict = {};
             dict[JointDataset.IndexLabel] = val;
             return dict;
         });
-        if (chartProps.chartType === ChartTypes.Scatter) {
-            const xAxis = chartProps.xAxis;
-            if (xAxis && xAxis.property && xAxis.options.dither) {
-                const rawX = cohort.unwrap(chartProps.xAxis.property);
-                rawX.forEach((val, index) => {
-                    // If categorical, show string value in tooltip
-                    if (jointData.metaDict[chartProps.xAxis.property].isCategorical) {
-                        customdata[index]["X"] = jointData.metaDict[chartProps.xAxis.property]
-                            .sortedCategoricalValues[val];
-                    } else {
-                        customdata[index]["X"] = val;
-                    }
+        let hovertemplate = "";
+        if (chartProps.xAxis) {
+            const metaX = this.props.jointDataset.metaDict[chartProps.xAxis.property];
+            const rawX = JointDataset.unwrap(dictionary, chartProps.xAxis.property);
+            if (metaX.isCategorical) {
+                hovertemplate += metaX.abbridgedLabel + ": %{customdata.X}<br>";
+                rawX.map((val, index) => {
+                    customdata[index]["X"] = metaX.sortedCategoricalValues[val]
                 });
-            }
-            const yAxis = chartProps.yAxis;
-            if (yAxis && yAxis.property && yAxis.options.dither) {
-                const rawY = cohort.unwrap(chartProps.yAxis.property);
-                rawY.forEach((val, index) => {
-                    // If categorical, show string value in tooltip
-                    if (jointData.metaDict[chartProps.yAxis.property].isCategorical) {
-                        customdata[index]["Y"] = jointData.metaDict[chartProps.yAxis.property]
-                            .sortedCategoricalValues[val];
-                    } else {
-                        customdata[index]["Y"] = val;
-                    }
-                });
+                if (chartProps.xAxis.options.dither) {
+                    const dither = JointDataset.unwrap(dictionary, JointDataset.DitherLabel);
+                    trace.x = dither.map((ditherVal, index) => { return rawX[index] + ditherVal; });
+                } else {
+                    trace.x = rawX;
+                }
+            } else {
+                hovertemplate += metaX.abbridgedLabel + ": %{x}<br>";
+                trace.x = rawX;
             }
         }
-        return customdata;
+        if (chartProps.yAxis) {
+            const metaY = this.props.jointDataset.metaDict[chartProps.yAxis.property];
+            const rawY = JointDataset.unwrap(dictionary, chartProps.yAxis.property);
+            if (metaY.isCategorical) {
+                hovertemplate += metaY.abbridgedLabel + ": %{customdata.Y}<br>";
+                rawY.map((val, index) => {
+                    customdata[index]["Y"] = metaY.sortedCategoricalValues[val]
+                });
+                if (chartProps.yAxis.options.dither) {
+                    const dither = JointDataset.unwrap(dictionary, JointDataset.DitherLabel);
+                    trace.y = dither.map((ditherVal, index) => { return rawY[index] + ditherVal; });
+                } else {
+                    trace.y = rawY;
+                }
+            } else {
+                hovertemplate += metaY.abbridgedLabel + ": %{y}<br>";
+                trace.y = rawY;
+            }
+        }
+        hovertemplate += localization.Charts.rowIndex + ": %{customdata.Index}<br>";
+        hovertemplate += "<extra></extra>";
+        trace.customdata = customdata as any;
+        trace.hovertemplate = hovertemplate;
     }
 
     private generateDefaultChartAxes(): void {

--- a/visualization/dashboard/src/MLIDashboard/FabricStyles.ts
+++ b/visualization/dashboard/src/MLIDashboard/FabricStyles.ts
@@ -61,6 +61,12 @@ export class FabricStyles {
         width: "100%"
     };
 
+    public static placeholderItalic: IStyle = {
+        fontStyle: "italic",
+        padding: "0 0 5px 5px",
+        color: getTheme().semanticColors.disabledBodyText
+    }
+
     public static missingParameterPlaceholderSpacer: IStyle = {
         margin: "25px auto 0 auto",
         maxWidth: "400px",

--- a/visualization/dashboard/src/MLIDashboard/JointDataset.ts
+++ b/visualization/dashboard/src/MLIDashboard/JointDataset.ts
@@ -21,7 +21,8 @@ export enum ColumnCategories {
     dataset = 'dataset',
     index = "index",
     explanation = 'explanation',
-    cohort = 'cohort'
+    cohort = 'cohort',
+    none = 'none'
 }
 
 export enum ClassificationEnum {
@@ -412,6 +413,13 @@ export class JointDataset {
             treatAsCategorical: true,
             category: ColumnCategories.cohort
         };
+        this.metaDict[ColumnCategories.none] = {
+            label: localization.Columns.none,
+            abbridgedLabel: localization.Columns.none,
+            isCategorical: true,
+            treatAsCategorical: true,
+            category: ColumnCategories.none
+        }
     }
 
     // project the 3d array based on the selected vector weights. Costly to do, so avoid when possible.


### PR DESCRIPTION
Add formatted tooltips to all charts (except box plots, which are not customizable in plotly at this time).
Set better defaults for charts.
Add 'count' option to data profile histogram view.
Fix bugs encountered while testing