### PR TITLE
fix keras dependency issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ prompt-toolkit>=2.0.0
 pytest==5.3.1
 flake8
 pyyaml
-keras
+keras<=2.3.1
 scipy==1.3.3
 flask
 flask-cors


### PR DESCRIPTION
fix keras dependency issue
Keras was recently updated which broke our builds.
Note: keras will be removed once we update to the next SHAP release, since it will be moved under tf.keras API