### PR TITLE
fix string class labels issue with mimic explainer

### DIFF
--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -10,7 +10,7 @@ from functools import wraps
 
 from .base_explainer import BaseExplainer
 from .aggregate import init_aggregator_decorator
-from .constants import ModelTask, ExplainParams
+from .constants import ModelTask, ExplainParams, SKLearn
 from .chained_identity import ChainedIdentity
 
 from .._internal.raw_explain.raw_explain_utils import get_datamapper_and_transformed_data
@@ -78,7 +78,7 @@ class BlackBoxMixin(ChainedIdentity):
         super(BlackBoxMixin, self).__init__(**kwargs)
         self._logger.debug('Initializing BlackBoxMixin')
         # If true, this is a classification model
-        self.predict_proba_flag = hasattr(model, "predict_proba")
+        self.predict_proba_flag = hasattr(model, SKLearn.PREDICT_PROBA)
 
         if is_function:
             self._logger.debug('Function passed in, no model')

--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -132,6 +132,7 @@ class SKLearn(object):
     EXAMPLES = 'examples'
     LABELS = 'labels'
     PREDICTIONS = 'predictions'
+    PREDICT_PROBA = 'predict_proba'
 
 
 class Spacy(object):

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -10,7 +10,7 @@ from ..common.structured_model_explainer import StructuredInitModelExplainer
 from ..common.explanation_utils import _fix_linear_explainer_shap_values
 from ..common.aggregate import add_explain_global_method, init_aggregator_decorator
 from ..common.constants import ExplainParams, Attributes, ExplainType, \
-    Defaults, Extension, SHAPDefaults
+    Defaults, Extension, SHAPDefaults, SKLearn
 from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import tabular_decorator
 from ..explanation.explanation import _create_local_explanation, \
@@ -195,7 +195,7 @@ class LinearExplainer(StructuredInitModelExplainer):
         if len(evaluation_examples.shape) == 1:
             evaluation_examples = evaluation_examples.reshape(1, -1)
         kwargs[ExplainParams.EVAL_Y_PRED] = self.model.predict(evaluation_examples)
-        if hasattr(self.model, 'predict_proba'):
+        if hasattr(self.model, SKLearn.PREDICT_PROBA):
             kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.model.predict_proba(evaluation_examples)
         return self._explain_global(wrapped_evals, **kwargs)
 
@@ -247,7 +247,7 @@ class LinearExplainer(StructuredInitModelExplainer):
         if len(evaluation_examples.shape) == 1:
             evaluation_examples = evaluation_examples.reshape(1, -1)
         kwargs[ExplainParams.EVAL_Y_PRED] = self.model.predict(evaluation_examples)
-        if hasattr(self.model, 'predict_proba'):
+        if hasattr(self.model, SKLearn.PREDICT_PROBA):
             kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.model.predict_proba(evaluation_examples)
         return kwargs
 

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -15,7 +15,7 @@ from ..explanation.explanation import _create_local_explanation, \
     _create_raw_feats_local_explanation, _get_raw_explainer_create_explanation_kwargs
 from .kwargs_utils import _get_explain_global_kwargs
 from ..common.constants import ExplainParams, Attributes, ExplainType, \
-    ShapValuesOutput, Defaults, Extension
+    ShapValuesOutput, Defaults, Extension, SKLearn
 from .._internal.raw_explain.raw_explain_utils import get_datamapper_and_transformed_data, \
     transform_with_datamapper
 from ..dataset.dataset_wrapper import DatasetWrapper
@@ -205,7 +205,7 @@ class TreeExplainer(PureStructuredModelExplainer):
         else:
             typed_evaluation_examples = evaluation_examples
         kwargs[ExplainParams.EVAL_Y_PRED] = self.model.predict(typed_evaluation_examples)
-        if hasattr(self.model, 'predict_proba'):
+        if hasattr(self.model, SKLearn.PREDICT_PROBA):
             kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.model.predict_proba(typed_evaluation_examples)
         return self._explain_global(wrapped_evals, **kwargs)
 
@@ -268,7 +268,7 @@ class TreeExplainer(PureStructuredModelExplainer):
         if len(evaluation_examples.shape) == 1:
             evaluation_examples = evaluation_examples.reshape(1, -1)
         kwargs[ExplainParams.EVAL_Y_PRED] = self.model.predict(typed_wrapper_func(evaluation_examples))
-        if hasattr(self.model, 'predict_proba'):
+        if hasattr(self.model, SKLearn.PREDICT_PROBA):
             kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.model.predict_proba(typed_wrapper_func(evaluation_examples))
         return kwargs
 

--- a/python/interpret_community/widget/explanation_dashboard_input.py
+++ b/python/interpret_community/widget/explanation_dashboard_input.py
@@ -6,6 +6,7 @@
 
 from ._internal.constants import ExplanationDashboardInterface, WidgetRequestResponseConstants
 from ..common.error_handling import _format_exception
+from ..common.constants import SKLearn
 from scipy.sparse import issparse
 import numpy as np
 import pandas as pd
@@ -63,7 +64,7 @@ class ExplanationDashboardInput:
         :type features: numpy.array or list[]
         """
         self._model = model
-        self._is_classifier = model is not None and hasattr(model, 'predict_proba') and \
+        self._is_classifier = model is not None and hasattr(model, SKLearn.PREDICT_PROBA) and \
             model.predict_proba is not None
         self._dataframeColumns = None
         self.dashboard_input = {}
@@ -177,7 +178,7 @@ class ExplanationDashboardInput:
                 raise ValueError("Class vector length mismatch: \
                     class names length differs from local explanations dimension")
             self.dashboard_input[ExplanationDashboardInterface.CLASS_NAMES] = classes
-        if model is not None and hasattr(model, 'predict_proba') \
+        if model is not None and hasattr(model, SKLearn.PREDICT_PROBA) \
                 and model.predict_proba is not None and dataset is not None:
             try:
                 probability_y = model.predict_proba(dataset)

--- a/test/datasets.py
+++ b/test/datasets.py
@@ -3,7 +3,7 @@ import os
 
 def retrieve_dataset(dataset, **kwargs):
     # if data not extracted, download zip and extract
-    outdirname = 'datasets.12.18.2019'
+    outdirname = 'datasets.7.20.2020'
     if not os.path.exists(outdirname):
         try:
             from urllib import urlretrieve


### PR DESCRIPTION
Fix string class labels issue with mimic explainer

Specifically, for some classifiers like SGDClassifier that don't have a predict_proba method and don't output probabilities, we were failing on using string labels.  The best solution is in the model_wrapper, where we can wrap the model to our specifications to output probabilities as a boolean vector array where class i = 1 and all else are 0.  This fix ensures that any classification models without a predict_proba (we will need to whitelist them) can fit our specifications for blackbox explainers.

Resolves user issue:
https://github.com/MicrosoftDocs/azure-docs/issues/59129#event-3571829770