### PR TITLE
Fix for job retries in pipelines

### DIFF
--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -70,4 +70,4 @@ steps:
     displayName: "Publish environment info to artifact ${{parameters.envInfoArtifact}}"
     inputs:
       path: '$(System.DefaultWorkingDirectory)/${{parameters.envInfoDirectory}}'
-      artifact: ${{parameters.envInfoArtifact}}
+      artifact: ${{parameters.envInfoArtifact}}-Attempt-$(System.JobAttemp

--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -70,4 +70,4 @@ steps:
     displayName: "Publish environment info to artifact ${{parameters.envInfoArtifact}}"
     inputs:
       path: '$(System.DefaultWorkingDirectory)/${{parameters.envInfoDirectory}}'
-      artifact: ${{parameters.envInfoArtifact}}-Attempt-$(System.JobAttemp
+      artifact: '${{parameters.envInfoArtifact}}-Attempt-$(System.JobAttempt)'


### PR DESCRIPTION
Retrying a job in an ADO pipeline would often fail because the Artifacts are immutable. Have the 'environment information' artifact append the job attempt in order to work around this.