### PR TITLE
handle case where classifier has predict function that returns probabilities in model wrapper

### DIFF
--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -136,6 +136,26 @@ def create_sklearn_random_forest_regressor(X, y):
     return model
 
 
+def wrap_classifier_without_proba(classifier):
+    # Wraps a classifier without a predict_proba
+    class WrappedWithoutProbaClassificationModel(object):
+        """A class for wrapping a classification model."""
+
+        def __init__(self, classifier):
+            """Initialize the WrappedWithoutProbaClassificationModel with the underlying model."""
+            self._model = classifier
+
+        def predict(self, dataset):
+            """Returns the probabilities instead of the predicted class.
+
+            :param dataset: The dataset to predict on.
+            :type dataset: DatasetWrapper
+            """
+            return self._model.predict_proba(dataset)
+
+    return WrappedWithoutProbaClassificationModel(classifier)
+
+
 def create_sklearn_linear_regressor(X, y, pipeline=False):
     lin = linear_model.LinearRegression(normalize=True)
     if pipeline:


### PR DESCRIPTION
Fix for customer where predict function was returning probabilities instead of predicted values for a classifier, and the model did not have a predict_proba method.  We can detect and handle this scenario in the model wrapper.  The crucial part is to return the argmax of the probabilities in the predict function for this scenario, since predict_proba is already handled by the wrapper - in order to ensure that the eval_y_predicted on the explanation are predictions and not probabilities.