### PR TITLE
added shap_values_output tests and fixed issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas
 sklearn_pandas
 hdbscan
 lightgbm
-xgboost
+xgboost<=1.0.0
 prompt-toolkit>=2.0.0
 pytest==5.3.1
 flake8

--- a/test/constants.py
+++ b/test/constants.py
@@ -11,3 +11,10 @@ class DatasetConstants(object):
     X_TRAIN = 'x_train'
     Y_TEST = 'y_test'
     Y_TRAIN = 'y_train'
+
+
+class ModelType(object):
+    """Model type constants."""
+    XGBOOST = 'xgboost'
+    TREE = 'tree'
+    DEFAULT = 'default'

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -25,7 +25,7 @@ from datasets import retrieve_dataset
 from sklearn import datasets
 import uuid
 
-from constants import owner_email_tools_and_ux
+from constants import owner_email_tools_and_ux, ModelType
 
 test_logger = logging.getLogger(__name__)
 test_logger.setLevel(logging.DEBUG)
@@ -214,6 +214,10 @@ class TestMimicExplainer(object):
         for verifier in verify_mimic_regressor:
             verifier.verify_explain_model_shap_values_binary()
 
+    def test_explain_model_shap_values_binary_xgboost(self, verify_mimic_regressor):
+        for verifier in verify_mimic_regressor:
+            verifier.verify_explain_model_shap_values_binary(model_type=ModelType.XGBOOST)
+
     def test_explain_model_shap_values_multiclass(self, verify_mimic_classifier):
         for verifier in verify_mimic_classifier:
             verifier.verify_explain_model_shap_values_multiclass()
@@ -221,6 +225,11 @@ class TestMimicExplainer(object):
     def test_explain_model_shap_values_binary_proba(self, verify_mimic_classifier):
         # Note: only LGBMExplainableModel supports conversion to probabilities for now
         verify_mimic_classifier[LGBM_MODEL_IDX].verify_explain_model_shap_values_binary(ShapValuesOutput.PROBABILITY)
+
+    def test_explain_model_shap_values_binary_proba_xgboost(self, verify_mimic_classifier):
+        # Note: only LGBMExplainableModel supports conversion to probabilities for now
+        verify_mimic_classifier[LGBM_MODEL_IDX].verify_explain_model_shap_values_binary(ShapValuesOutput.PROBABILITY,
+                                                                                        model_type=ModelType.XGBOOST)
 
     def test_explain_model_shap_values_multiclass_proba(self, verify_mimic_classifier):
         # Note: only LGBMExplainableModel supports conversion to probabilities for now
@@ -231,6 +240,12 @@ class TestMimicExplainer(object):
         # Note: only LGBMExplainableModel supports conversion to probabilities for now
         verify_mimic = verify_mimic_classifier[LGBM_MODEL_IDX]
         verify_mimic.verify_explain_model_shap_values_binary(ShapValuesOutput.TEACHER_PROBABILITY)
+
+    def test_explain_model_shap_values_binary_teacher_proba_xgboost(self, verify_mimic_classifier):
+        # Note: only LGBMExplainableModel supports conversion to probabilities for now
+        verify_mimic = verify_mimic_classifier[LGBM_MODEL_IDX]
+        verify_mimic.verify_explain_model_shap_values_binary(ShapValuesOutput.TEACHER_PROBABILITY,
+                                                             model_type=ModelType.XGBOOST)
 
     def test_explain_model_shap_values_multiclass_teacher_proba(self, verify_mimic_classifier):
         # Note: only LGBMExplainableModel supports conversion to probabilities for now

--- a/test/test_misc_explainers.py
+++ b/test/test_misc_explainers.py
@@ -13,10 +13,11 @@ from interpret_community.shap.kernel_explainer import KernelExplainer
 from interpret_community.shap.tree_explainer import TreeExplainer
 from interpret_community.shap.deep_explainer import DeepExplainer
 from interpret_community.shap.linear_explainer import LinearExplainer
+from interpret_community.common.constants import ShapValuesOutput
 from common_tabular_tests import VerifyTabularTests
 from common_utils import create_keras_multiclass_classifier, create_keras_regressor, \
     create_sklearn_linear_regressor, create_sklearn_logistic_regressor
-from constants import owner_email_tools_and_ux
+from constants import owner_email_tools_and_ux, ModelType
 
 test_logger = logging.getLogger(__name__)
 test_logger.setLevel(logging.INFO)
@@ -115,6 +116,31 @@ class TestTreeExplainer(object):
     def test_tree_explainer_raw_transformations_column_transformer_regression(self):
         self._verify_tabular.verify_explain_model_transformations_list_regression(self._get_create_model(
             classification=False))
+
+    def test_tree_explainer_shap_values_binary_xgboost(self):
+        self._verify_tabular.verify_explain_model_shap_values_binary(model_type=ModelType.XGBOOST)
+
+    def test_tree_explainer_shap_values_binary_proba(self):
+        self._verify_tabular.verify_explain_model_shap_values_binary(ShapValuesOutput.PROBABILITY,
+                                                                     model_type=ModelType.TREE)
+
+    def test_tree_explainer_shap_values_binary_proba_xgboost(self):
+        self._verify_tabular.verify_explain_model_shap_values_binary(ShapValuesOutput.PROBABILITY,
+                                                                     model_type=ModelType.XGBOOST)
+
+    def test_tree_explainer_shap_values_multiclass(self):
+        self._verify_tabular.verify_explain_model_shap_values_multiclass(model_type=ModelType.TREE)
+
+    def test_tree_explainer_shap_values_multiclass_proba(self):
+        self._verify_tabular.verify_explain_model_shap_values_multiclass(ShapValuesOutput.PROBABILITY,
+                                                                         model_type=ModelType.TREE)
+
+    def test_tree_explainer_shap_values_multiclass_proba_xgboost(self):
+        self._verify_tabular.verify_explain_model_shap_values_multiclass(ShapValuesOutput.PROBABILITY,
+                                                                         model_type=ModelType.XGBOOST)
+
+    def test_tree_explainer_shap_values_regression(self):
+        self._verify_tabular.verify_explain_model_shap_values_regression(model_type=ModelType.TREE)
 
 
 @pytest.mark.owner(email=owner_email_tools_and_ux)


### PR DESCRIPTION
added tests for shap_values_output for tree explainer and mimic explainer, fixed issue with XGBoost and TreeExplainer case
Note latest XGBoost doesn't work with shap 0.34.0 so I pinned it, there is a serialization issues which is already fixed in latest shap, but requires us upgrading to it.