### PR TITLE
release interpret-community v0.14.4

### DIFF
--- a/python/interpret_community/__init__.py
+++ b/python/interpret_community/__init__.py
@@ -35,5 +35,5 @@ if interpret_c_logs is not None:
 __name__ = 'interpret_community'
 _major = '0'
 _minor = '14'
-_patch = '3'
+_patch = '4'
 __version__ = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- fix open in new tab on public VMs (specifically tested on Azure DSVM)
-  handle case where classifier has predict function that returns probabilities in model wrapper
-  added tests for shap_values_output for tree explainer and mimic explainer, fixed issue with XGBoost and TreeExplainer case