### PR TITLE
optimize data mapper memory usage

### DIFF
--- a/python/interpret_community/_internal/raw_explain/feature_mappers.py
+++ b/python/interpret_community/_internal/raw_explain/feature_mappers.py
@@ -4,9 +4,12 @@
 
 from abc import ABCMeta, abstractmethod
 import numpy as np
+from scipy.sparse import eye, csr_matrix
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import Binarizer, KernelCenterer, LabelEncoder, MaxAbsScaler, MinMaxScaler, Normalizer, \
     OneHotEncoder, QuantileTransformer, RobustScaler, StandardScaler
+
+CSR_FORMAT = 'csr'
 
 
 def get_feature_mapper_for_pipeline(pipeline_obj):
@@ -111,7 +114,7 @@ class IdentityMapper(FeatureMapper):
         :param num_cols: number of columns in input.
         :type num_cols: int
         """
-        self.set_feature_map(np.eye(num_cols))
+        self.set_feature_map(eye(num_cols, format=CSR_FORMAT))
 
     def transform(self, x):
         """Transform input data.
@@ -216,7 +219,7 @@ class OneHotEncoderMapper(FeatureMapper):
         cat_lens = [len(cat) for cat in self.transformer.categories_]
         output_cols = int(sum(cat_lens))
         input_cols = len(self.transformer.categories_)
-        feature_map = np.zeros((input_cols, output_cols))
+        feature_map = csr_matrix((input_cols, output_cols))
         last_num_cols = 0
         for i, cat_len in enumerate(cat_lens):
             feature_map[i, last_num_cols:(last_num_cols + cat_len)] = np.ones((cat_len))

--- a/test/raw_explain/test_data_mapper.py
+++ b/test/raw_explain/test_data_mapper.py
@@ -53,6 +53,20 @@ class TestDataMapper:
         result = data_mapper.transform(x)
         assert result.shape == (2, 2)
 
+    def test_large_sparse_transformation(self):
+        x = np.linspace((1,) * 8000, (10,) * 8000, 10)
+        encoder = OneHotEncoder()
+        encoder.fit(x)
+        data_mapper = DataMapper([(np.arange(8000), encoder)])
+        result = data_mapper.transform(x)
+        assert result.shape == (10, 80000)
+        for i in range(10):
+            for j in range(i, 80000, 10):
+                assert result[i, j] == 1
+                result[i, j] = 0
+        result.eliminate_zeros()
+        assert result.count_nonzero() == 0
+
     def test_transform_numpy_list(self):
         self._transform_numpy(self._identity_mapper_list)
 


### PR DESCRIPTION
Optimize data mapper memory usage by using sparse format (for raw features transformations)

In the test case added, there was a mapping from 8000 raw columns to 80000 engineered columns, which resulted in >4.7 GB dense matrix in memory (which led to OOM on my machine).  Using sparse format resolved this issue and vastly reduced overall memory usage.