### PR TITLE
fix issues with importing version in setup.py before dependencies installed

### DIFF
--- a/python/interpret_community/__init__.py
+++ b/python/interpret_community/__init__.py
@@ -7,8 +7,9 @@
 You can use model interpretability to explain why a model model makes the predictions it does and help build
 confidence in the model.
 """
-
 from .tabular_explainer import TabularExplainer
+from .version import name, version
+
 
 __all__ = ["TabularExplainer"]
 
@@ -32,8 +33,5 @@ if interpret_c_logs is not None:
         logger.removeHandler(handler)
     atexit.register(close_handler)
 
-__name__ = 'interpret_community'
-_major = '0'
-_minor = '14'
-_patch = '4'
-__version__ = '{}.{}.{}'.format(_major, _minor, _patch)
+__name__ = name
+__version__ = version

--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,0 +1,5 @@
+name = 'interpret_community'
+_major = '0'
+_minor = '14'
+_patch = '4'
+version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/python/setup.py
+++ b/python/setup.py
@@ -6,8 +6,11 @@
 from setuptools import setup, find_packages
 import os
 import shutil
-import interpret_community
 
+
+with open('interpret_community/version.py') as f:
+    code = compile(f.read(), f.name, 'exec')
+    exec(code)
 
 README_FILE = 'README.md'
 LICENSE_FILE = 'LICENSE.txt'
@@ -67,9 +70,9 @@ with open(README_FILE, 'r', encoding='utf-8') as f:
     README = f.read()
 
 setup(
-    name=interpret_community.__name__,
+    name=name,  # noqa: F821
 
-    version=interpret_community.__version__,
+    version=version,  # noqa: F821
 
     description='Microsoft Interpret Extensions SDK for Python',
     long_description=README,


### PR DESCRIPTION
for reference, please see stack overflow:
https://stackoverflow.com/questions/2058802/how-can-i-get-the-version-defined-in-setup-py-setuptools-in-my-package

note it is not recommended to do what we recently switched to, which is importing the package in setup.py, because it causes a lot of issues during install, forcing the user to install all of the dependencies before running pip install on the interpret-community setup.py.