### PR TITLE
add true_y parameter to ExplanationDashboard notebooks to demonstrate additional functionality

### DIFF
--- a/notebooks/advanced-feature-transformations-explain-local.ipynb
+++ b/notebooks/advanced-feature-transformations-explain-local.ipynb
@@ -456,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, datasetX=x_test)"
+    "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)"
    ]
   },
   {

--- a/notebooks/explain-binary-classification-local.ipynb
+++ b/notebooks/explain-binary-classification-local.ipynb
@@ -335,7 +335,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, datasetX=x_test)"
+    "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)"
    ]
   },
   {

--- a/notebooks/explain-multiclass-classification-local.ipynb
+++ b/notebooks/explain-multiclass-classification-local.ipynb
@@ -337,7 +337,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, datasetX=x_test)"
+    "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)"
    ]
   },
   {

--- a/notebooks/explain-regression-local.ipynb
+++ b/notebooks/explain-regression-local.ipynb
@@ -327,7 +327,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, datasetX=x_test)"
+    "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)"
    ]
   },
   {

--- a/notebooks/simple-feature-transformations-explain-local.ipynb
+++ b/notebooks/simple-feature-transformations-explain-local.ipynb
@@ -464,7 +464,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, datasetX=x_test)"
+    "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)"
    ]
   },
   {

--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -21,8 +21,10 @@ def append_scrapbook_commands(input_nb_path, output_nb_path, scrap_specs):
     # Don't use CDN when running notebook tests
     for cell in notebook['cells']:
         if cell.cell_type == 'code' and "ExplanationDashboard(" in cell.source:
-            if "ExplanationDashboard(global_explanation, model, datasetX=x_test)" in cell.source:
-                cell.source = cell.source.replace("datasetX=x_test)", "datasetX=x_test, use_cdn=False)")
+            if "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)" in cell.source:
+                string_match = "datasetX=x_test, true_y=y_test)"
+                string_replace = "datasetX=x_test, true_y=y_test, use_cdn=False)"
+                cell.source = cell.source.replace(string_match, string_replace)
             else:
                 raise Exception("ExplanationDashboard added in new format and could not be replaced. "
                                 "Please replace code in tests to use_cdn in test_notebooks")


### PR DESCRIPTION
Add true_y parameter to ExplanationDashboard notebooks to demonstrate additional functionality

This allows users to see:
1.) The model performance statistics
2.) Have additional true_y data available in dropdowns for various graphs