### PR TITLE
fix tolist error for sparse feature importances and sparse raw_to_output_map on creating raw explanation

### DIFF
--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -97,9 +97,10 @@ def _get_raw_feature_importances(importance_values, raw_to_output_feature_maps):
             raw_importances = _multiply_sparse_matrix_3d_numpy_tensor(importance_values, raw_to_output_map.T)
         else:
             raw_importances = raw_to_output_map.dot(importance_values.T).T
+            if issparse(raw_importances):
+                raw_importances = raw_importances.toarray()
     else:
         raw_importances = importance_values.dot(raw_to_output_map.T)
-
     return raw_importances.squeeze(0) if orig_single_dimensional_importances else raw_importances
 
 

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -452,6 +452,22 @@ class TestMimicExplainer(object):
         global_explanation = explainer.explain_global(X.iloc[:1000])
         assert global_explanation.method == LINEAR_METHOD
 
+    def test_linear_explainable_model_regression(self, mimic_explainer):
+        num_features = 3
+        x_train = np.array([['a', 'E', 'x'], ['c', 'D', 'y']])
+        y_train = np.array([1, 2])
+        lin = LinearRegression(normalize=True)
+        one_hot_transformer = Pipeline(steps=[('one-hot', OneHotEncoder())])
+        transformations = [(list(range(num_features)), one_hot_transformer)]
+        clf = Pipeline(steps=[('preprocessor', one_hot_transformer), ('regressor', lin)])
+        model = clf.fit(x_train, y_train)
+        explainable_model = LinearExplainableModel
+        explainer = mimic_explainer(model.named_steps['regressor'], x_train, explainable_model,
+                                    transformations=transformations, augment_data=False,
+                                    explainable_model_args={'sparse_data': True}, features=['f1', 'f2', 'f3'])
+        global_explanation = explainer.explain_global(x_train)
+        assert global_explanation.method == LINEAR_METHOD
+
     @property
     def iris_overall_expected_features(self):
         return [['petal length', 'petal width', 'sepal width', 'sepal length'],


### PR DESCRIPTION
fix tolist error for sparse feature importances and sparse raw_to_output_map on creating raw explanation

This error seems to occur when the engineered feature importances are sparse and the raw_to_output_map is sparse for regression scenario.
The error is related to this recent data mapper memory optimization:
https://github.com/interpretml/interpret-community/pull/313