### PR TITLE
release interpret-community v0.15.1

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
 _minor = '15'
-_patch = '0'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
-  fix tolist error for sparse feature importances and sparse raw_to_output_map on creating raw explanation
-  move LIME from azureml-contrib-interpret package to interpret-community
-  fix error during visualization on explanation with id for eval_y_predicted and eval_y_predicted_proba in datasets mixin
-  add true_y parameter to ExplanationDashboard notebooks to demonstrate additional functionality