### PR TITLE
remove cdn from explanation dashboard

### DIFF
--- a/python/interpret_community/widget/templates/inlineDashboard.html
+++ b/python/interpret_community/widget/templates/inlineDashboard.html
@@ -1,8 +1,5 @@
 <!doctype html>
 <title>Interpret Dashboard</title>
-{% if using_fallback %}
-    <div style="background-color: #fee12b; width: 100%;">Could not use CDN for dashboard javascript. Falling back to local index.js</div>
-{% endif %}
 {% if has_local_url %}
     <a href="{{local_url}}" target="_blank">Open in new tab</a>
 {% endif %}

--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -18,16 +18,6 @@ def append_scrapbook_commands(input_nb_path, output_nb_path, scrap_specs):
         source = "sb.glue(\"{0}\", {1})".format(k, v)
         scrapbook_cells.append(nbf.v4.new_code_cell(source=source))
 
-    # Don't use CDN when running notebook tests
-    for cell in notebook['cells']:
-        if cell.cell_type == 'code' and "ExplanationDashboard(" in cell.source:
-            if "ExplanationDashboard(global_explanation, model, datasetX=x_test, true_y=y_test)" in cell.source:
-                string_match = "datasetX=x_test, true_y=y_test)"
-                string_replace = "datasetX=x_test, true_y=y_test, use_cdn=False)"
-                cell.source = cell.source.replace(string_match, string_replace)
-            else:
-                raise Exception("ExplanationDashboard added in new format and could not be replaced. "
-                                "Please replace code in tests to use_cdn in test_notebooks")
     # Append the cells to the notebook
     [notebook['cells'].append(c) for c in scrapbook_cells]
 


### PR DESCRIPTION
removes the use_cdn flag and related code from explanation dashboard in order to simplify maintenance.  Users who continue to pass use_cdn flag will see a warning that it has been deprecated.