### PR TITLE
release interpret-community 0.15.3

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
 _minor = '15'
-_patch = '2'
+_patch = '3'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- fix issue with serializing the lightgbm surrogate model on mimic explainer for lightgbm >= 3.0.0