### PR TITLE
various memory optimizations

### DIFF
--- a/python/interpret_community/dataset/decorator.py
+++ b/python/interpret_community/dataset/decorator.py
@@ -23,6 +23,12 @@ def tabular_decorator(explain_func):
     return explain_func_wrapper
 
 
+def wrap_dataset(dataset):
+    if not isinstance(dataset, DatasetWrapper):
+        dataset = DatasetWrapper(dataset)
+    return dataset
+
+
 def init_tabular_decorator(init_func):
     """Decorate a constructor to wrap initialization examples in a DatasetWrapper.
 
@@ -33,7 +39,5 @@ def init_tabular_decorator(init_func):
     """
     @wraps(init_func)
     def init_wrapper(self, model, initialization_examples, *args, **kwargs):
-        if not isinstance(initialization_examples, DatasetWrapper):
-            initialization_examples = DatasetWrapper(initialization_examples)
-        return init_func(self, model, initialization_examples, *args, **kwargs)
+        return init_func(self, model, wrap_dataset(initialization_examples), *args, **kwargs)
     return init_wrapper

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -13,7 +13,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression, LinearRegression
 from sklearn.base import TransformerMixin
-from lightgbm import LGBMClassifier
+from lightgbm import LGBMClassifier, LGBMRegressor
 from xgboost import XGBClassifier
 
 from tensorflow import keras
@@ -95,6 +95,13 @@ def create_sklearn_random_forest_classifier(X, y):
 def create_lightgbm_classifier(X, y):
     lgbm = LGBMClassifier(boosting_type='gbdt', learning_rate=0.1,
                           max_depth=5, n_estimators=200, n_jobs=1, random_state=777)
+    model = lgbm.fit(X, y)
+    return model
+
+
+def create_lightgbm_regressor(X, y):
+    lgbm = LGBMRegressor(boosting_type='gbdt', learning_rate=0.1,
+                         max_depth=5, n_estimators=200, n_jobs=1, random_state=777)
     model = lgbm.fit(X, y)
     return model
 

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -22,7 +22,8 @@ from interpret_community.common.constants import ShapValuesOutput, ModelTask
 from interpret_community.mimic.models.lightgbm_model import LGBMExplainableModel
 from interpret_community.mimic.models.linear_model import LinearExplainableModel
 from common_utils import create_sklearn_svm_classifier, create_sklearn_linear_regressor, \
-    create_iris_data, create_cancer_data, create_energy_data, create_timeseries_data
+    create_iris_data, create_cancer_data, create_energy_data, create_timeseries_data, \
+    create_lightgbm_regressor
 from models import DataFrameTestModel, SkewedTestModel
 from datasets import retrieve_dataset
 from sklearn import datasets
@@ -504,6 +505,23 @@ class TestMimicExplainer(object):
                                     model_task=ModelTask.Classification)
         global_explanation = explainer.explain_global(evaluation_examples=data_x)
         assert global_explanation.method == LINEAR_METHOD
+
+    def test_dense_wide_data(self, mimic_explainer):
+        # use 6000 rows instead for real performance testing
+        data = np.random.randn(50, 40000)
+        feature_names = [f'f_{i}' for i in range(39999)]
+        column_names = [f'f_{i}' for i in range(39999)]
+        column_names.append('label')
+        dataframe1 = pd.DataFrame(data, columns=column_names)
+        df_y = dataframe1['label']
+        df_X = dataframe1.drop(columns='label')
+        # Fit a lightgbm regression model
+        model = create_lightgbm_regressor(df_X, df_y)
+        explainable_model = LGBMExplainableModel
+        explainer = mimic_explainer(model, df_X, explainable_model, augment_data=False,
+                                    features=feature_names)
+        global_explanation = explainer.explain_global(df_X)
+        assert global_explanation.method == LIGHTGBM_METHOD
 
     @property
     def iris_overall_expected_features(self):


### PR DESCRIPTION
various memory optimizations in interpret-community done as part of integration with another product
- where possible use _local_importance_values since local_importance_values converts from numpy to list
- avoid typed_dataset in some paths since that creates a new pandas dataframe
- add clear_references parameter to DatasetWrapper such that it can be cleared after use, which should reduce memory usage - note this is only for users who know what they are doing
- added test for dense and wide data which can be used for future performance testing as well