### PR TITLE
Add predicted and predicted probabilities to raw explanations

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -473,6 +473,8 @@ class LocalExplanation(FeatureImportanceExplanation):
         raw_kwargs[ExplainParams.FEATURES] = raw_feature_names
         raw_kwargs[ExplainParams.IS_RAW] = True
         raw_kwargs[ExplainParams.EVAL_DATA] = eval_data
+        raw_kwargs[ExplainParams.EVAL_Y_PRED] = self.eval_y_predicted
+        raw_kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.eval_y_predicted_proba
         self._is_eng = True
         return _create_raw_feats_local_explanation(self, feature_maps=feature_maps, **raw_kwargs)
 

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1402,7 +1402,7 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None or kwargs[ExplainParams.EVAL_Y_PRED] is not None or kwargs[ExplainParams.EVAL_Y_PRED_PROBA] is not None:
+    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data
@@ -1477,7 +1477,7 @@ def _create_global_explanation_kwargs(local_explanation=None, expected_values=No
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None or kwargs[ExplainParams.EVAL_Y_PRED] is not None or kwargs[ExplainParams.EVAL_Y_PRED_PROBA] is not None:
+    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -736,6 +736,8 @@ class GlobalExplanation(FeatureImportanceExplanation):
         raw_kwargs[ExplainParams.FEATURES] = raw_feature_names
         raw_kwargs[ExplainParams.IS_RAW] = True
         raw_kwargs[ExplainParams.EVAL_DATA] = eval_data
+        raw_kwargs[ExplainParams.EVAL_Y_PRED] = self.eval_y_predicted
+        raw_kwargs[ExplainParams.EVAL_Y_PRED_PROBA] = self.eval_y_predicted_proba
         self._is_eng = True
         return _create_raw_feats_global_explanation(self, feature_maps=feature_maps, **raw_kwargs)
 
@@ -1355,7 +1357,7 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None:
+    if init_data is not None or eval_data is not None or kwargs[ExplainParams.EVAL_Y_PRED] is not None or kwargs[ExplainParams.EVAL_Y_PRED_PROBA] is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data
@@ -1430,7 +1432,7 @@ def _create_global_explanation_kwargs(local_explanation=None, expected_values=No
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None:
+    if init_data is not None or eval_data is not None or kwargs[ExplainParams.EVAL_Y_PRED] is not None or kwargs[ExplainParams.EVAL_Y_PRED_PROBA] is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1402,7 +1402,8 @@ def _create_local_explanation(expected_values=None, classification=True, explana
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
+    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or \
+            kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data
@@ -1477,7 +1478,8 @@ def _create_global_explanation_kwargs(local_explanation=None, expected_values=No
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
     else:
         kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
-    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
+    if init_data is not None or eval_data is not None or kwargs.get(ExplainParams.EVAL_Y_PRED) is not None or \
+            kwargs.get(ExplainParams.EVAL_Y_PRED_PROBA) is not None:
         mixins.append(_DatasetsMixin)
         if init_data is not None:
             kwargs[ExplainParams.INIT_DATA] = init_data

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -16,13 +16,13 @@ from sklearn.base import TransformerMixin
 from lightgbm import LGBMClassifier, LGBMRegressor
 from xgboost import XGBClassifier
 
-from tensorflow import keras
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense, Dropout, Activation
+# from tensorflow import keras
+# from tensorflow.keras.models import Sequential
+# from tensorflow.keras.layers import Dense, Dropout, Activation
 
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
+# import torch
+# import torch.nn as nn
+# import torch.nn.functional as F
 
 from pandas import read_csv
 

--- a/test/raw_explain/test_raw_explanation.py
+++ b/test/raw_explain/test_raw_explanation.py
@@ -220,6 +220,7 @@ class TestRawExplanations:
         assert hasattr(raw_explanation, 'eval_data') == has_raw_eval_data
         assert not raw_explanation.is_engineered
         assert np.array(raw_explanation.global_importance_values).shape[-1] == feature_map.shape[0]
+        assert raw_explanation.eval_y_predicted is not None
 
     def validate_global_explanation_classification(self, eng_explanation, raw_explanation,
                                                    feature_map, classes, feature_names, is_sparse=False,

--- a/test/raw_explain/test_raw_explanation.py
+++ b/test/raw_explain/test_raw_explanation.py
@@ -215,10 +215,16 @@ class TestRawExplanations:
         assert np.array(raw_explanation.local_importance_values).shape[-1] == feature_map.shape[0]
 
         assert raw_explanation.is_raw
-        assert hasattr(raw_explanation, 'eval_data') == has_raw_eval_data
         assert not raw_explanation.is_engineered
         assert np.array(raw_explanation.global_importance_values).shape[-1] == feature_map.shape[0]
+
+        # Test the y_pred and y_pred_proba on the raw explanations
         assert raw_explanation.eval_y_predicted is not None
+        assert raw_explanation.eval_y_predicted_proba is None
+
+        # Test the raw data on the raw explanations
+        assert hasattr(raw_explanation, 'eval_data')
+        assert (raw_explanation.eval_data is not None) == has_raw_eval_data
 
     def validate_global_explanation_classification(self, eng_explanation, raw_explanation,
                                                    feature_map, classes, feature_names, is_sparse=False,
@@ -235,12 +241,11 @@ class TestRawExplanations:
         assert len(raw_explanation.get_ranked_per_class_names()[0]) == feature_map.shape[0]
         feat_imps_global_local = np.array(raw_explanation.local_importance_values)
         assert feat_imps_global_local.shape[-1] == feature_map.shape[0]
-
         assert raw_explanation.is_raw
-        assert hasattr(raw_explanation, 'eval_data') == has_raw_eval_data
         assert not raw_explanation.is_engineered
         assert len(raw_explanation.get_ranked_global_values()) == feature_map.shape[0]
         assert len(raw_explanation.get_ranked_global_names()) == feature_map.shape[0]
+
         if isinstance(classes, list):
             assert raw_explanation.classes == classes
         else:
@@ -251,3 +256,11 @@ class TestRawExplanations:
         feat_imps_global = np.array(raw_explanation.global_importance_values)
 
         assert feat_imps_global.shape[-1] == feature_map.shape[0]
+
+        # Test the y_pred and y_pred_proba on the raw explanations
+        assert raw_explanation.eval_y_predicted is not None
+        assert raw_explanation.eval_y_predicted_proba is not None
+
+        # Test the raw data on the raw explanations
+        assert hasattr(raw_explanation, 'eval_data')
+        assert (raw_explanation.eval_data is not None) == has_raw_eval_data


### PR DESCRIPTION
It seems y_pred and y_pred_proba are not added from the engineered explanations to raw explanations. This causes the model performance tab to not show y_pred/y_pred_proba for raw explanations.

Signed-off-by: Gaurav Gupta <gaugup@microsoft.com>