### PR TITLE
various memory optimizations for explain API

### DIFF
--- a/python/interpret_community/_internal/raw_explain/feature_mappers.py
+++ b/python/interpret_community/_internal/raw_explain/feature_mappers.py
@@ -8,8 +8,7 @@ from scipy.sparse import eye, csr_matrix
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import Binarizer, KernelCenterer, LabelEncoder, MaxAbsScaler, MinMaxScaler, Normalizer, \
     OneHotEncoder, QuantileTransformer, RobustScaler, StandardScaler
-
-CSR_FORMAT = 'csr'
+from ...common.constants import Scipy
 
 
 def get_feature_mapper_for_pipeline(pipeline_obj):
@@ -114,7 +113,7 @@ class IdentityMapper(FeatureMapper):
         :param num_cols: number of columns in input.
         :type num_cols: int
         """
-        self.set_feature_map(eye(num_cols, format=CSR_FORMAT))
+        self.set_feature_map(eye(num_cols, format=Scipy.CSR_FORMAT))
 
     def transform(self, x):
         """Transform input data.

--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -143,6 +143,12 @@ class Spacy(object):
     TAGGER = 'tagger'
 
 
+class Scipy(object):
+    """Provide scipy related constants."""
+
+    CSR_FORMAT = 'csr'
+
+
 class ModelTask(str, Enum):
     """Provide model task constants. Can be 'classification', 'regression', or 'unknown'.
 

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -371,7 +371,7 @@ class MimicExplainer(BlackBoxExplainer):
             # explanation and then aggregating or streaming the local explanation to global
             if include_local:
                 # Get local explanation
-                local_explanation = self.explain_local(evaluation_examples)
+                local_explanation = self._explain_local(evaluation_examples, from_global=True)
                 kwargs[ExplainParams.LOCAL_EXPLANATION] = local_explanation
             else:
                 if classification:
@@ -460,21 +460,23 @@ class MimicExplainer(BlackBoxExplainer):
         """
         return "{}.{}".format(ExplainType.MIMIC, self._method)
 
-    def _get_explain_local_kwargs(self, evaluation_examples):
+    def _get_explain_local_kwargs(self, evaluation_examples, from_global):
         """Get the kwargs for explain_local to create a local explanation.
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
         :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :param from_global: True if this is called from the explain_global API.
+        :type from_global: bool
         :return: Args for explain_local.
         :rtype: dict
         """
         if self.reset_index != ResetIndex.Ignore:
             evaluation_examples.reset_index()
         kwargs = {}
-        original_evaluation_examples = evaluation_examples.typed_dataset
         probabilities = None
         if self._shap_values_output == ShapValuesOutput.TEACHER_PROBABILITY:
+            original_evaluation_examples = evaluation_examples.typed_dataset
             # Outputting shap values in terms of the probabilities of the teacher model
             probabilities = self.function(original_evaluation_examples)
         # if index column should not be set on surrogate model, remove it
@@ -538,13 +540,63 @@ class MimicExplainer(BlackBoxExplainer):
         kwargs[ExplainParams.LOCAL_IMPORTANCE_VALUES] = local_importance_values
         kwargs[ExplainParams.EXPECTED_VALUES] = np.array(expected_values)
         kwargs[ExplainParams.CLASSIFICATION] = classification
-        kwargs[ExplainParams.INIT_DATA] = self.initialization_examples
-        kwargs[ExplainParams.EVAL_DATA] = original_evaluation_examples
-        ys_dict = self._get_ys_dict(self._original_eval_examples,
-                                    transformations=self.transformations,
-                                    allow_all_transformations=self._allow_all_transformations)
-        kwargs.update(ys_dict)
+        if not from_global:
+            ys_dict = self._get_ys_dict(self._original_eval_examples,
+                                        transformations=self.transformations,
+                                        allow_all_transformations=self._allow_all_transformations)
+            kwargs.update(ys_dict)
         return kwargs
+
+    def _explain_local_helper(self, evaluation_examples, from_global):
+        """Helper method to create the local explanation.
+
+        :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
+            to explain the model's output.
+        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :param from_global: True if this is called from the explain_global API.
+        :type from_global: bool
+        :return: kwargs for building the model explanation object
+        :rtype: dict
+        """
+        if not from_global:
+            if self._original_eval_examples is None:
+                if isinstance(evaluation_examples, DatasetWrapper):
+                    self._original_eval_examples = evaluation_examples.original_dataset_with_type
+                else:
+                    self._original_eval_examples = evaluation_examples
+        if self._datamapper is not None:
+            new_evaluation_examples = transform_with_datamapper(evaluation_examples, self._datamapper)
+            # memory optimization to clear all internal references so they can be gc'ed as soon as possible
+            evaluation_examples._clear()
+            evaluation_examples = new_evaluation_examples
+
+        kwargs = self._get_explain_local_kwargs(evaluation_examples, from_global)
+        if not from_global:
+            kwargs[ExplainParams.INIT_DATA] = self.initialization_examples
+            kwargs[ExplainParams.EVAL_DATA] = evaluation_examples
+        return kwargs
+
+    @tabular_decorator
+    def _explain_local(self, evaluation_examples, from_global=False):
+        """Locally explains the blackbox model using the surrogate model.
+
+        :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
+            to explain the model's output.
+        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :param from_global: True if this is called from the explain_global API.
+        :type from_global: bool
+        :return: A model explanation object. It is guaranteed to be a LocalExplanation. If the model is a classifier,
+            it will have the properties of the ClassesMixin.
+        :rtype: DynamicLocalExplanation
+        """
+        kwargs = self._explain_local_helper(evaluation_examples, from_global)
+        explanation = _create_local_explanation(**kwargs)
+
+        # if transformations have been passed, then return raw features explanation
+        raw_kwargs = _get_raw_explainer_create_explanation_kwargs(kwargs=kwargs)
+
+        return explanation if self._datamapper is None else _create_raw_feats_local_explanation(
+            explanation, feature_maps=[self._datamapper.feature_map], features=self.features, **raw_kwargs)
 
     @tabular_decorator
     def explain_local(self, evaluation_examples):
@@ -557,27 +609,7 @@ class MimicExplainer(BlackBoxExplainer):
             it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
         """
-        if self._original_eval_examples is None:
-            if isinstance(evaluation_examples, DatasetWrapper):
-                self._original_eval_examples = evaluation_examples.original_dataset_with_type
-            else:
-                self._original_eval_examples = evaluation_examples
-        if self._datamapper is not None:
-            new_evaluation_examples = transform_with_datamapper(evaluation_examples, self._datamapper)
-            # memory optimization to clear all internal references so they can be gc'ed as soon as possible
-            evaluation_examples._clear()
-            evaluation_examples = new_evaluation_examples
-
-        kwargs = self._get_explain_local_kwargs(evaluation_examples)
-        kwargs[ExplainParams.INIT_DATA] = self.initialization_examples
-        kwargs[ExplainParams.EVAL_DATA] = evaluation_examples
-        explanation = _create_local_explanation(**kwargs)
-
-        # if transformations have been passed, then return raw features explanation
-        raw_kwargs = _get_raw_explainer_create_explanation_kwargs(kwargs=kwargs)
-
-        return explanation if self._datamapper is None else _create_raw_feats_local_explanation(
-            explanation, feature_maps=[self._datamapper.feature_map], features=self.features, **raw_kwargs)
+        return self._explain_local(evaluation_examples)
 
     def _save(self):
         """Return a string dictionary representation of the mimic explainer.

--- a/test/test_explanation_utils.py
+++ b/test/test_explanation_utils.py
@@ -6,13 +6,15 @@ import pytest
 
 import numpy as np
 import logging
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, eye
 
 from interpret_community.common.explanation_utils import _convert_to_list, _generate_augmented_data, \
     _get_raw_feature_importances, _is_one_to_many, _sort_values, _sort_feature_list_single, \
-    _sort_feature_list_multiclass, _two_dimensional_slice, _get_feature_map_from_list_of_indexes
+    _sort_feature_list_multiclass, _two_dimensional_slice, _get_feature_map_from_list_of_indexes, \
+    _is_identity
 
 from raw_explain.utils import _get_feature_map_from_indices_list
+from interpret_community.common.constants import Scipy
 from constants import owner_email_tools_and_ux
 
 test_logger = logging.getLogger(__name__)
@@ -188,3 +190,11 @@ class TestExplanationUtils(object):
         assert _is_one_to_many(one_to_many)
         assert not _is_one_to_many(many_to_one)
         assert not _is_one_to_many(many_to_many)
+
+    def test_is_identity(self):
+        identity = eye(10, format=Scipy.CSR_FORMAT)
+        assert _is_identity(identity)
+        dense_not_identity = np.ones((10, 20))
+        assert not _is_identity(dense_not_identity)
+        sparse_not_identity = csr_matrix(dense_not_identity)
+        assert not _is_identity(sparse_not_identity)


### PR DESCRIPTION
various memory optimizations to the explanation-related APIs, particularly explain_global, including:

1.) preventing matrix multiply if matrix is identity in engineered to raw mapping (which happens very often) - this significantly reduces memory usage
2.) differentiating between call from explain_global vs explain_local when entering _explain_local which allows us to skip some duplicate computations which lead to higher memory usage
3.) refactoring out into functions (eg _explain_local_helper) which allows GC of various temporary variables (I could have also used del but it looks much uglier)

These memory optimizations allowed AzureML designer run to complete on 6k X 40k dense dataset (with passed transformations)