### PR TITLE
fix categorical handling for scikit-learn 0.24 during one hot encoding for failing test

### DIFF
--- a/python/interpret_community/dataset/dataset_wrapper.py
+++ b/python/interpret_community/dataset/dataset_wrapper.py
@@ -368,7 +368,7 @@ class DatasetWrapper(object):
         self._one_hot_encoder = ColumnTransformer([('ord', one_hot_encoder, columns)], remainder='passthrough')
         # Note this will change column order, the one hot encoded columns will be at the start and the
         # rest of the columns at the end
-        self._dataset = self._one_hot_encoder.fit_transform(self._dataset).astype(float)
+        self._dataset = self._one_hot_encoder.fit_transform(self._dataset.astype(float)).astype(float)
         return self._one_hot_encoder
 
     def timestamp_featurizer(self):

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -650,6 +650,5 @@ class MimicExplainer(BlackBoxExplainer):
         :param dict: A dictionary of deserialized state.
         :type dict: dict
         """
-        print(state)
         self.__dict__.update(state)
         self._logger = logging.getLogger(__name__)


### PR DESCRIPTION
When updating to scikit-learn 0.24, one hot encoder can no longer handle apply on columns of object type.  This caused the test case test_explain_model_categorical to start failing for mimic explainer:

```
TypeError: ufunc 'isnan' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

For this specific case, where the dataset has categorical values, we explicitly cast the dataset to float prior to fitting the one-hot-encoder which resolves the issue.