### PR TITLE
upgrade setuptools to latest to fix pypi upload error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools>=51.0.0
 xmlrunner
 tensorflow<2.0.0
 scikit-learn


### PR DESCRIPTION
pypi upload scripts are failing due to old version of setuptools, see issue and suggested fix for context:
https://github.com/actions/setup-python/issues/165