### PR TITLE
fix interpret-community namespaces to be compatible with newer version of shap

### DIFF
--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -17,8 +17,10 @@ import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
     import shap
-    from shap.common import DenseData
-
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 module_logger = logging.getLogger(__name__)
 module_logger.setLevel(logging.INFO)

--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -15,7 +15,10 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    from shap.common import DenseData
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 
 module_logger = logging.getLogger(__name__)

--- a/python/interpret_community/dataset/dataset_wrapper.py
+++ b/python/interpret_community/dataset/dataset_wrapper.py
@@ -18,7 +18,10 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    from shap.common import DenseData
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 SAMPLED_STRING_ROWS = 10
 

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -14,7 +14,10 @@ from scipy.sparse import issparse
 
 from abc import ABCMeta, abstractmethod
 
-from shap.common import DenseData
+try:
+    from shap.common import DenseData
+except:
+    from shap.utils._legacy import DenseData
 from interpret.utils import gen_local_selector, gen_global_selector, gen_name_from_class
 
 from ..common.explanation_utils import _sort_values, _order_imp, _sort_feature_list_single, \

--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -30,7 +30,10 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    from shap.common import DenseData
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 
 @add_prepare_function_and_summary_method

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -40,7 +40,10 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    from shap.common import DenseData
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 
 class MimicExplainer(BlackBoxExplainer):

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -15,7 +15,10 @@ import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
     import shap
-    from shap.common import DenseData
+    try:
+        from shap.common import DenseData
+    except:
+        from shap.utils._legacy import DenseData
 
 DEFAULT_RANDOM_STATE = 123
 FEATURE_DEPENDENCE = 'interventional'

--- a/test/test_serialize_explanation.py
+++ b/test/test_serialize_explanation.py
@@ -17,7 +17,10 @@ from common_utils import create_sklearn_svm_classifier
 from constants import DatasetConstants
 from constants import owner_email_tools_and_ux
 from interpret_community.dataset.dataset_wrapper import DatasetWrapper
-from shap.common import DenseData
+try:
+    from shap.common import DenseData
+except:
+    from shap.utils._legacy import DenseData
 
 test_logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
fix interpret-community namespaces to be compatible with newer version of shap
note this was done as part of a demo where azureml-interpret was able to serialize newer shap explantions.  This seems like a good change to make in preparation for the move to the newer version of shap that will happen later this semester.