### PR TITLE
fix load explanation methods for numpy based variables

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -95,6 +95,11 @@ class ExplainParams(object):
                 vars(cls).keys())) - set(['DATA_MAPPER', 'DATA_MAPPER_INTERNAL']))
 
 
+class PrivateExplainParams(object):
+    U_LOCAL_IMPORTANCE_VALUES = '_' + ExplainParams.LOCAL_IMPORTANCE_VALUES
+    U_EVAL_DATA = '_' + ExplainParams.EVAL_DATA
+
+
 class Defaults(object):
     """Provide constants for default values to explain methods."""
 

--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -94,10 +94,16 @@ class ExplainParams(object):
         return (set(filter(lambda x: not x.startswith('__') and not callable(getattr(cls, x)),
                 vars(cls).keys())) - set(['DATA_MAPPER', 'DATA_MAPPER_INTERNAL']))
 
+    @classmethod
+    def get_private(cls, explain_param):
+        """Return the private version of the ExplainParams property.
 
-class PrivateExplainParams(object):
-    U_LOCAL_IMPORTANCE_VALUES = '_' + ExplainParams.LOCAL_IMPORTANCE_VALUES
-    U_EVAL_DATA = '_' + ExplainParams.EVAL_DATA
+        :param explain_param: The ExplainParams property to get private version of.
+        :type explain_param: str
+        :return: The private version of the property.
+        :rtype: str
+        """
+        return '_' + explain_param
 
 
 class Defaults(object):

--- a/test/common_tabular_tests.py
+++ b/test/common_tabular_tests.py
@@ -24,12 +24,13 @@ from interpret_community.common.constants import ExplainParams, ShapValuesOutput
 from interpret_community.common.explanation_utils import _summarize_data
 from interpret_community.common.policy import SamplingPolicy
 
-from common_utils import create_sklearn_svm_classifier, create_sklearn_linear_regressor, \
-    create_sklearn_logistic_regressor, create_iris_data, create_energy_data, create_cancer_data, \
-    create_pandas_only_svm_classifier, create_keras_regressor, create_pytorch_regressor, \
-    create_keras_multiclass_classifier, create_pytorch_multiclass_classifier, \
-    create_multiclass_sparse_newsgroups_data, create_xgboost_classifier, \
-    create_sklearn_random_forest_regressor, create_sklearn_random_forest_classifier
+from common_utils import (create_sklearn_svm_classifier, create_sklearn_linear_regressor,
+                          create_sklearn_logistic_regressor, create_iris_data, create_energy_data,
+                          create_cancer_data, create_msx_data, create_pandas_only_svm_classifier,
+                          create_keras_regressor, create_pytorch_regressor,
+                          create_keras_multiclass_classifier, create_pytorch_multiclass_classifier,
+                          create_multiclass_sparse_newsgroups_data, create_xgboost_classifier,
+                          create_sklearn_random_forest_regressor, create_sklearn_random_forest_classifier)
 from raw_explain.utils import IdentityTransformer
 from test_serialize_explanation import verify_serialization
 from constants import ModelType
@@ -456,7 +457,7 @@ class VerifyTabularTests(object):
 
     def verify_explain_model_npz_linear(self, include_evaluation_examples=True, true_labels_required=False):
         # run explain model on a real sparse dataset from the field
-        x_train, x_test, y_train, y_test = self.create_msx_data(0.05)
+        x_train, x_test, y_train, y_test = create_msx_data(0.05)
         x_train = x_train[DATA_SLICE]
         x_test = x_test[DATA_SLICE]
         y_train = y_train[DATA_SLICE]
@@ -597,7 +598,7 @@ class VerifyTabularTests(object):
     def verify_explain_model_subset_regression_sparse(self, is_local=True,
                                                       true_labels_required=False):
         # Verify explaining a subset of the features, but on sparse regression data
-        x_train, x_test, y_train, y_test = self.create_msx_data(0.01)
+        x_train, x_test, y_train, y_test = create_msx_data(0.01)
         DATA_SLICE = slice(100)
         x_train = x_train[DATA_SLICE]
         x_test = x_test[DATA_SLICE]
@@ -685,7 +686,7 @@ class VerifyTabularTests(object):
 
     def verify_explain_model_with_sampling_regression_sparse(self, true_labels_required=False):
         # Verify that evaluation dataset can be downsampled
-        x_train, x_test, y_train, y_test = self.create_msx_data(0.2)
+        x_train, x_test, y_train, y_test = create_msx_data(0.2)
         x_train = x_train[DATA_SLICE]
         x_test = x_test[DATA_SLICE]
         y_train = y_train[DATA_SLICE]
@@ -954,12 +955,6 @@ class VerifyTabularTests(object):
                     assert(predicted_probability <= ubound and predicted_probability >= lbound)
                     if model_output is not None:
                         assert abs(predicted_probability - model_output[row_idx, class_idx]) < TOLERANCE
-
-    def create_msx_data(self, test_size):
-        sparse_matrix = retrieve_dataset('msx_transformed_2226.npz')
-        sparse_matrix_x = sparse_matrix[:, :sparse_matrix.shape[1] - 2]
-        sparse_matrix_y = sparse_matrix[:, (sparse_matrix.shape[1] - 2):(sparse_matrix.shape[1] - 1)]
-        return train_test_split(sparse_matrix_x, sparse_matrix_y, test_size=test_size, random_state=7)
 
     def verify_energy_overall_features(self,
                                        ranked_global_names,

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -411,6 +411,13 @@ def create_scikit_cancer_data():
     return x_train, x_test, y_train, y_test, feature_names, classes
 
 
+def create_msx_data(test_size):
+    sparse_matrix = retrieve_dataset('msx_transformed_2226.npz')
+    sparse_matrix_x = sparse_matrix[:, :sparse_matrix.shape[1] - 2]
+    sparse_matrix_y = sparse_matrix[:, (sparse_matrix.shape[1] - 2):(sparse_matrix.shape[1] - 1)]
+    return train_test_split(sparse_matrix_x, sparse_matrix_y, test_size=test_size, random_state=7)
+
+
 def create_binary_classification_dataset():
     from sklearn.datasets import make_classification
     import pandas as pd

--- a/test/test_explain_model.py
+++ b/test/test_explain_model.py
@@ -13,10 +13,11 @@ import pandas as pd
 
 from interpret_community.common.policy import SamplingPolicy
 
-from common_utils import create_sklearn_random_forest_classifier, create_sklearn_svm_classifier, \
-    create_sklearn_random_forest_regressor, create_sklearn_linear_regressor, create_keras_classifier, \
-    create_keras_regressor, create_lightgbm_classifier, create_pytorch_classifier, create_pytorch_regressor, \
-    create_xgboost_classifier, wrap_classifier_without_proba
+from common_utils import (create_sklearn_random_forest_classifier, create_sklearn_svm_classifier,
+                          create_sklearn_random_forest_regressor, create_sklearn_linear_regressor,
+                          create_keras_classifier, create_keras_regressor, create_lightgbm_classifier,
+                          create_pytorch_classifier, create_pytorch_regressor, create_xgboost_classifier,
+                          create_msx_data, wrap_classifier_without_proba)
 from raw_explain.utils import _get_feature_map_from_indices_list
 from interpret_community.common.constants import ModelTask
 from constants import DatasetConstants
@@ -262,7 +263,7 @@ class TestTabularExplainer(object):
 
     def test_explain_model_npz_tree(self, tabular_explainer):
         # run explain global on a real sparse dataset from the field
-        x_train, x_test, y_train, _ = self.create_msx_data(0.1)
+        x_train, x_test, y_train, _ = create_msx_data(0.1)
         x_train = x_train[DATA_SLICE]
         x_test = x_test[DATA_SLICE]
         y_train = y_train[DATA_SLICE]
@@ -675,12 +676,6 @@ class TestTabularExplainer(object):
         explanation = exp.explain_global(x_test)
         # Validate predicted y values are boolean
         assert(np.all(np.isin(explanation.eval_y_predicted, [0, 1])))
-
-    def create_msx_data(self, test_size):
-        sparse_matrix = retrieve_dataset('msx_transformed_2226.npz')
-        sparse_matrix_x = sparse_matrix[:, :sparse_matrix.shape[1] - 2]
-        sparse_matrix_y = sparse_matrix[:, (sparse_matrix.shape[1] - 2):(sparse_matrix.shape[1] - 1)]
-        return train_test_split(sparse_matrix_x, sparse_matrix_y, test_size=test_size, random_state=7)
 
     def verify_adult_overall_features(self, ranked_global_names, ranked_global_values):
         # Verify order of features

--- a/test/test_serialize_explanation.py
+++ b/test/test_serialize_explanation.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 import os
 
-from interpret_community.common.constants import ExplainParams, PrivateExplainParams
+from interpret_community.common.constants import ExplainParams
 from interpret_community.explanation.explanation import save_explanation, load_explanation
 from interpret_community.mimic.models.lightgbm_model import LGBMExplainableModel
 from common_utils import (create_sklearn_svm_classifier, create_sklearn_linear_regressor,
@@ -47,21 +47,21 @@ class TestSerializeExplanation(object):
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
         explanation = explainer.explain_local(iris[DatasetConstants.X_TEST])
-        verify_serialization(explanation, assert_types=True)
+        verify_serialization(explanation, assert_numpy_types=True)
 
     def test_save_and_load_explanation_global_only(self, iris, tabular_explainer, iris_svm_model):
         explainer = tabular_explainer(iris_svm_model,
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
         explanation = explainer.explain_global(iris[DatasetConstants.X_TEST], include_local=False)
-        verify_serialization(explanation, assert_types=True)
+        verify_serialization(explanation, assert_numpy_types=True)
 
     def test_save_and_load_explanation_global_and_local(self, iris, tabular_explainer, iris_svm_model):
         explainer = tabular_explainer(iris_svm_model,
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
         explanation = explainer.explain_global(iris[DatasetConstants.X_TEST])
-        verify_serialization(explanation, assert_types=True)
+        verify_serialization(explanation, assert_numpy_types=True)
 
     @pytest.mark.skip(reason="save_explanation and load_explanation do not support sparse data yet")
     def test_save_and_load_sparse_explanation(self, mimic_explainer):
@@ -102,11 +102,11 @@ def _assert_explanation_equivalence(actual, expected):
 
 def _assert_numpy_explanation_types(actual, expected):
     # assert "_" variables equivalence
-    if hasattr(actual, PrivateExplainParams.U_LOCAL_IMPORTANCE_VALUES):
+    if hasattr(actual, ExplainParams.get_private(ExplainParams.LOCAL_IMPORTANCE_VALUES)):
         assert(isinstance(actual._local_importance_values, np.ndarray))
         assert(isinstance(expected._local_importance_values, np.ndarray))
         np.testing.assert_array_equal(actual._local_importance_values, expected._local_importance_values)
-    if hasattr(actual, PrivateExplainParams.U_EVAL_DATA):
+    if hasattr(actual, ExplainParams.get_private(ExplainParams.EVAL_DATA)):
         assert(isinstance(actual._eval_data, np.ndarray))
         assert(isinstance(expected._eval_data, np.ndarray))
         np.testing.assert_array_equal(actual._eval_data, expected._eval_data)
@@ -116,12 +116,12 @@ def _assert_numpy_explanation_types(actual, expected):
 # tests to verify that the de-serialized result is equivalent to the original
 # exposed outside this module to allow any test involving an explanation to
 # incorporate serialization testing
-def verify_serialization(explanation, extra_path=None, exist_ok=False, assert_types=False):
+def verify_serialization(explanation, extra_path=None, exist_ok=False, assert_numpy_types=False):
     path = 'brand/new/path'
     if extra_path is not None:
         path = os.path.join(path, extra_path)
     save_explanation(explanation, path, exist_ok=exist_ok)
     loaded_explanation = load_explanation(path)
     _assert_explanation_equivalence(explanation, loaded_explanation)
-    if assert_types:
+    if assert_numpy_types:
         _assert_numpy_explanation_types(explanation, loaded_explanation)

--- a/test/test_serialize_explanation.py
+++ b/test/test_serialize_explanation.py
@@ -11,9 +11,11 @@ import numpy as np
 import pandas as pd
 import os
 
-from interpret_community.common.constants import ExplainParams
+from interpret_community.common.constants import ExplainParams, PrivateExplainParams
 from interpret_community.explanation.explanation import save_explanation, load_explanation
-from common_utils import create_sklearn_svm_classifier
+from interpret_community.mimic.models.lightgbm_model import LGBMExplainableModel
+from common_utils import (create_sklearn_svm_classifier, create_sklearn_linear_regressor,
+                          create_msx_data)
 from constants import DatasetConstants
 from constants import owner_email_tools_and_ux
 from interpret_community.dataset.dataset_wrapper import DatasetWrapper
@@ -45,20 +47,30 @@ class TestSerializeExplanation(object):
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
         explanation = explainer.explain_local(iris[DatasetConstants.X_TEST])
-        verify_serialization(explanation)
+        verify_serialization(explanation, assert_types=True)
 
     def test_save_and_load_explanation_global_only(self, iris, tabular_explainer, iris_svm_model):
         explainer = tabular_explainer(iris_svm_model,
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
         explanation = explainer.explain_global(iris[DatasetConstants.X_TEST], include_local=False)
-        verify_serialization(explanation)
+        verify_serialization(explanation, assert_types=True)
 
     def test_save_and_load_explanation_global_and_local(self, iris, tabular_explainer, iris_svm_model):
         explainer = tabular_explainer(iris_svm_model,
                                       iris[DatasetConstants.X_TRAIN],
                                       features=iris[DatasetConstants.FEATURES])
-        explanation = explainer.explain_global(iris[DatasetConstants.X_TEST], include_local=False)
+        explanation = explainer.explain_global(iris[DatasetConstants.X_TEST])
+        verify_serialization(explanation, assert_types=True)
+
+    @pytest.mark.skip(reason="save_explanation and load_explanation do not support sparse data yet")
+    def test_save_and_load_sparse_explanation(self, mimic_explainer):
+        x_train, x_test, y_train, y_test = create_msx_data(0.05)
+        # Fit a linear regression model
+        model = create_sklearn_linear_regressor(x_train, y_train.toarray().flatten())
+        explainable_model = LGBMExplainableModel
+        explainer = mimic_explainer(model, x_train, explainable_model, augment_data=False)
+        explanation = explainer.explain_global(x_test)
         verify_serialization(explanation)
 
 
@@ -88,14 +100,28 @@ def _assert_explanation_equivalence(actual, expected):
             assert actual_value == expected_value
 
 
+def _assert_numpy_explanation_types(actual, expected):
+    # assert "_" variables equivalence
+    if hasattr(actual, PrivateExplainParams.U_LOCAL_IMPORTANCE_VALUES):
+        assert(isinstance(actual._local_importance_values, np.ndarray))
+        assert(isinstance(expected._local_importance_values, np.ndarray))
+        np.testing.assert_array_equal(actual._local_importance_values, expected._local_importance_values)
+    if hasattr(actual, PrivateExplainParams.U_EVAL_DATA):
+        assert(isinstance(actual._eval_data, np.ndarray))
+        assert(isinstance(expected._eval_data, np.ndarray))
+        np.testing.assert_array_equal(actual._eval_data, expected._eval_data)
+
+
 # performs serialization and de-serialization for any explanation
 # tests to verify that the de-serialized result is equivalent to the original
 # exposed outside this module to allow any test involving an explanation to
 # incorporate serialization testing
-def verify_serialization(explanation, extra_path=None, exist_ok=False):
+def verify_serialization(explanation, extra_path=None, exist_ok=False, assert_types=False):
     path = 'brand/new/path'
     if extra_path is not None:
         path = os.path.join(path, extra_path)
     save_explanation(explanation, path, exist_ok=exist_ok)
     loaded_explanation = load_explanation(path)
     _assert_explanation_equivalence(explanation, loaded_explanation)
+    if assert_types:
+        _assert_numpy_explanation_types(explanation, loaded_explanation)


### PR DESCRIPTION
A user wanted to save and load explanations using save/load methods to json (without using explanationclient), however these were not deserializing the local importance values properly as a numpy array, leading to exceptions when viewed in widget.    This PR resolves this.  In the process of adding tests, I found a host of other issues:
1.) We weren't saving/loading some properties like eval_data, init_data and pred_y/pred_proba_y (fixed in this PR)
2.) The save/load explanation code can't handle sparse data, I've added a disabled test and created a github issue to track this (https://github.com/interpretml/interpret-community/issues/378)