### PR TITLE
release interpret-community 0.17.1

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
 _minor = '17'
-_patch = '0'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
patch release 0.17.1 of interpret-community SDK
- fix sphinx documentation issue with constants params
- remove private methods as these are not being called from anywhere in the interpret-community SDK:
  - _transform_data
  - _unsort_2d
