### PR TITLE
fix sparse linear surrogate model stuck in optimization

### DIFF
--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -26,6 +26,7 @@ LINEAR_LBFGS = 'lbfgs'
 LINEAR_MULTICLASS = 'multi_class'
 LINEAR_MULTINOMIAL = 'multinomial'
 LINEAR_RANDOM_STATE = 'random_state'
+LINEAR_FIT_INTERCEPT = 'fit_intercept'
 
 
 class LinearExplainer(shap.LinearExplainer):
@@ -198,6 +199,7 @@ class LinearExplainableModel(BaseExplainableModel):
         else:
             if self._sparse_data:
                 initializer = Lasso
+                kwargs[LINEAR_FIT_INTERCEPT] = False
             else:
                 initializer = LinearRegression
         initializer_args = _get_initializer_args(kwargs)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -56,7 +56,7 @@ def get_mimic_method(surrogate_model):
         raise Exception("Unsupported surrogate model")
 
 
-def create_binary_sparse_newsgroups_data():
+def create_binary_sparse_newsgroups_data(n_features=2**16):
     categories = ['alt.atheism', 'soc.religion.christian']
     newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
     newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
@@ -67,7 +67,7 @@ def create_binary_sparse_newsgroups_data():
     y_validation = newsgroups_test.target
     from sklearn.feature_extraction.text import HashingVectorizer
     vectorizer = HashingVectorizer(stop_words='english', alternate_sign=False,
-                                   n_features=2**16)
+                                   n_features=n_features)
     x_train = vectorizer.transform(x_train)
     x_test = vectorizer.transform(x_test)
     return x_train, x_test, y_train, y_validation, class_names, vectorizer

--- a/test/sparse_utils.py
+++ b/test/sparse_utils.py
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+# Defines helper utilities for working with sparse data
+import numpy as np
+from scipy.sparse import csr_matrix
+
+
+def tile_csr_matrix(matrix, nsamples):
+    shape = matrix.shape
+    nnz = matrix.nnz
+    data_rows, data_cols = shape
+    rows = data_rows * nsamples
+    shape = rows, data_cols
+    if nnz == 0:
+        tiled_data = csr_matrix(shape, dtype=matrix.dtype)
+    else:
+        data = matrix.data
+        indices = matrix.indices
+        indptr = matrix.indptr
+        last_indptr_idx = indptr[len(indptr) - 1]
+        indptr_wo_last = indptr[:-1]
+        new_indptrs = []
+        for i in range(0, nsamples - 1):
+            new_indptrs.append(indptr_wo_last + (i * last_indptr_idx))
+        new_indptrs.append(indptr + ((nsamples - 1) * last_indptr_idx))
+        new_indptr = np.concatenate(new_indptrs)
+        new_data = np.tile(data, nsamples)
+        new_indices = np.tile(indices, nsamples)
+        tiled_data = csr_matrix((new_data, new_indices, new_indptr), shape=shape)
+    return tiled_data


### PR DESCRIPTION
For linear surrogate model we use lasso regression for sparse data.  This can sometimes take a long time to run or even get stuck during training on data that hasn't been normalized.  It is recommended to normalize the data before running Lasso regression.  However, for sparse data, fit_intercept isn't that useful and it seems to make it more prone to get stuck in optimization.  Removing this parameter here for now, although in the future we may want to add it back in, if we find that it significantly impacts surrogate model accuracy on sparse data in some cases (I haven't seen this yet in testing).