### PR TITLE
fix model type parameter being called and defined incorrectly in mimic explainer

### DIFF
--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -287,7 +287,7 @@ class MimicExplainer(BlackBoxExplainer):
         self._timestamp_featurizer = initialization_examples.timestamp_featurizer()
 
         # If model is a linear model or isn't able to handle categoricals, one-hot-encode categoricals
-        is_tree_model = explainable_model.explainable_model_type == ExplainableModelType.TREE_EXPLAINABLE_MODEL_TYPE
+        is_tree_model = explainable_model.explainable_model_type() == ExplainableModelType.TREE_EXPLAINABLE_MODEL_TYPE
         if is_tree_model and self._supports_categoricals(explainable_model):
             # Index the categorical string columns for training data
             self._column_indexer = initialization_examples.string_index(columns=categorical_features)

--- a/python/interpret_community/mimic/models/explainable_model.py
+++ b/python/interpret_community/mimic/models/explainable_model.py
@@ -78,7 +78,7 @@ class BaseExplainableModel(ChainedIdentity):
         pass
 
     @staticmethod
-    def explainable_model_type(self):
+    def explainable_model_type():
         """Retrieve the model type."""
         pass
 

--- a/python/interpret_community/mimic/models/lightgbm_model.py
+++ b/python/interpret_community/mimic/models/lightgbm_model.py
@@ -239,7 +239,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         return self._lgbm
 
     @staticmethod
-    def explainable_model_type(self):
+    def explainable_model_type():
         """Retrieve the model type.
 
         :return: Tree explainable model type.

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -327,7 +327,7 @@ class LinearExplainableModel(BaseExplainableModel):
         return self._linear
 
     @staticmethod
-    def explainable_model_type(self):
+    def explainable_model_type():
         """Retrieve the model type.
 
         :return: Linear explainable model type.

--- a/python/interpret_community/mimic/models/tree_model.py
+++ b/python/interpret_community/mimic/models/tree_model.py
@@ -175,7 +175,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         return self._tree
 
     @staticmethod
-    def explainable_model_type(self):
+    def explainable_model_type():
         """Retrieve the model type.
 
         :return: Tree explainable model type.

--- a/test/common_tabular_tests.py
+++ b/test/common_tabular_tests.py
@@ -869,7 +869,7 @@ class VerifyTabularTests(object):
         self.validate_explanation(explanation, is_probability=False, is_regression=True,
                                   model_output=model_output)
 
-    def verify_explain_model_categorical(self, pass_categoricals=False):
+    def verify_explain_model_categorical(self, pass_categoricals=False, verify_same_shape=False):
         headers = ["symboling", "normalized_losses", "make", "fuel_type", "aspiration",
                    "num_doors", "body_style", "drive_wheels", "engine_location",
                    "wheel_base", "length", "width", "height", "curb_weight",
@@ -918,6 +918,9 @@ class VerifyTabularTests(object):
             explainer = self.create_explainer(pipeline, imp_train_X)
         explanation = explainer.explain_global(imp_X.transform(df_test_X))
         verify_serialization(explanation, exist_ok=True)
+        # validate explanation when passing categoricals is for raw features for some specific explainers
+        if pass_categoricals and verify_same_shape:
+            assert np.array(explanation.local_importance_values).shape[1] == df_train_X.shape[1]
 
     def validate_explanation(self, explanation, is_multiclass=False, is_probability=False,
                              is_regression=False, model_output=None):

--- a/test/test_lime_explainer.py
+++ b/test/test_lime_explainer.py
@@ -97,7 +97,8 @@ class TestLIMEExplainer(object):
         self.verify_tabular.verify_explain_model_local_single()
 
     def test_explain_model_categorical(self):
-        self.verify_tabular.verify_explain_model_categorical(pass_categoricals=True)
+        self.verify_tabular.verify_explain_model_categorical(pass_categoricals=True,
+                                                             verify_same_shape=True)
 
     def test_explain_with_transformations_list_classification(self):
         self.verify_tabular.verify_explain_model_transformations_list_classification()

--- a/test/test_mimic_explainer.py
+++ b/test/test_mimic_explainer.py
@@ -282,8 +282,10 @@ class TestMimicExplainer(object):
         assert global_explanation.method == LIGHTGBM_METHOD
 
     def test_explain_model_categorical(self, verify_mimic_regressor):
-        for verifier in verify_mimic_regressor:
-            verifier.verify_explain_model_categorical(pass_categoricals=True)
+        for idx, verifier in enumerate(verify_mimic_regressor):
+            verify_same_shape = idx == LGBM_MODEL_IDX
+            verifier.verify_explain_model_categorical(pass_categoricals=True,
+                                                      verify_same_shape=verify_same_shape)
 
     @pytest.mark.parametrize("sample_cnt_per_grain,grains_dict", [
         (240, {}),


### PR DESCRIPTION
related to issue:
https://github.com/interpretml/interpret-community/issues/390

the static "explainable_model_type" method was not 1.) called correctly from mimic explainer 2.) defined correctly on surrogate models
I fixed both issues and added more validation logic.  This doesn't actually throw an error, but for tree surrogate models we were one-hot-encoding instead of only string indexing