### PR TITLE
remove warning on mimic explainer relating to categorical features

### DIFF
--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -292,7 +292,8 @@ class MimicExplainer(BlackBoxExplainer):
             # Index the categorical string columns for training data
             self._column_indexer = initialization_examples.string_index(columns=categorical_features)
             self._one_hot_encoder = None
-            explainable_model_args[LightGBMParams.CATEGORICAL_FEATURE] = categorical_features
+            if categorical_features:
+                explainable_model_args[LightGBMParams.CATEGORICAL_FEATURE] = categorical_features
         else:
             # One-hot-encode categoricals for models that don't support categoricals natively
             self._column_indexer = initialization_examples.string_index(columns=categorical_features)


### PR DESCRIPTION
remove annoying warning in notebook relating to categorical features being specified when the list is empty in mimic explainer for a lightgbm surrogate model:

![image](https://user-images.githubusercontent.com/24683184/113910444-d773fc00-97a6-11eb-8bbd-7072f7406bef.png)
