### PR TITLE
remove shap DenseData from supported input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ jupyter notebook
 # <a name="models"></a>
 # Supported Models
 
-This API supports models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, `iml.datatypes.DenseData`, or `scipy.sparse.csr_matrix` format.
+This API supports models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, or `scipy.sparse.csr_matrix` format.
 
 
 The explanation functions accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the Scikit convention. If not compatible, you can wrap your model's prediction function into a wrapper function that transforms the output into the format that is supported (predict or predict_proba of Scikit), and pass that wrapper function to your selected interpretability techniques.  

--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -22,8 +22,7 @@ class _Wrapper(object):
 
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param function: The function to explain.
     :type function: function that accepts a 2d ndarray
     """
@@ -33,8 +32,7 @@ class _Wrapper(object):
 
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param function: The function to explain.
         :type function: function that accepts a 2d ndarray
         """

--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -47,19 +47,20 @@ def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
     :rtype: numpy.array or scipy.sparse.csr_matrix or DenseData
     """
     is_sparse = issparse(X)
-    if is_sparse:
-        module_logger.debug('Creating sparse data summary as csr matrix')
-        # calculate median of sparse background data
-        median_dense = csc_median_axis_0(X.tocsc())
-        return csr_matrix(median_dense)
-    elif len(X) > 10 * k:
-        module_logger.debug('Create dense data summary with k-means')
-        # use kmeans to summarize the examples for initialization
-        # if there are more than 10 x k of them
-        if use_gpu:
-            return kmeans(X, k, to_round_values)
-        else:
-            return shap.kmeans(X, k, to_round_values)
+    if not str(type(X)).endswith(".DenseData'>"):
+        if is_sparse:
+            module_logger.debug('Creating sparse data summary as csr matrix')
+            # calculate median of sparse background data
+            median_dense = csc_median_axis_0(X.tocsc())
+            return csr_matrix(median_dense)
+        elif len(X) > 10 * k:
+            module_logger.debug('Create dense data summary with k-means')
+            # use kmeans to summarize the examples for initialization
+            # if there are more than 10 x k of them
+            if use_gpu:
+                return kmeans(X, k, to_round_values)
+            else:
+                return shap.kmeans(X, k, to_round_values)
     return X
 
 

--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -409,6 +409,8 @@ def _eval_function(function, examples, model_task, wrapped=False):
     # it in a function that converts a 1D array to 2D for those functions
     # that only support 2D arrays as input
     examples_dataset = examples.dataset
+    if str(type(examples_dataset)).endswith(".DenseData'>"):
+        examples_dataset = examples_dataset.data
     try:
         result = function(examples.typed_wrapper_func(examples_dataset[0]))
     except Exception as ex:

--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -15,10 +15,6 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    try:
-        from shap.common import DenseData
-    except ImportError:
-        from shap.utils._legacy import DenseData
 
 
 module_logger = logging.getLogger(__name__)
@@ -413,8 +409,6 @@ def _eval_function(function, examples, model_task, wrapped=False):
     # it in a function that converts a 1D array to 2D for those functions
     # that only support 2D arrays as input
     examples_dataset = examples.dataset
-    if isinstance(examples_dataset, DenseData):
-        examples_dataset = examples_dataset.data
     try:
         result = function(examples.typed_wrapper_func(examples_dataset[0]))
     except Exception as ex:

--- a/python/interpret_community/common/structured_model_explainer.py
+++ b/python/interpret_community/common/structured_model_explainer.py
@@ -16,8 +16,7 @@ class StructuredInitModelExplainer(BaseExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     """
 
     def __init__(self, model, initialization_examples, **kwargs):
@@ -27,8 +26,7 @@ class StructuredInitModelExplainer(BaseExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         """
         super(StructuredInitModelExplainer, self).__init__(**kwargs)
         self._logger.debug('Initializing StructuredInitModelExplainer')

--- a/python/interpret_community/dataset/dataset_wrapper.py
+++ b/python/interpret_community/dataset/dataset_wrapper.py
@@ -18,10 +18,6 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    try:
-        from shap.common import DenseData
-    except ImportError:
-        from shap.utils._legacy import DenseData
 
 SAMPLED_STRING_ROWS = 10
 
@@ -47,13 +43,12 @@ class CustomTimestampFeaturizer(BaseEstimator, TransformerMixin):
         """Fits the CustomTimestampFeaturizer.
 
         :param X: The dataset containing timestamp columns to featurize.
-        :type X: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type X: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         """
         # If the data was previously successfully summarized, then there are no
         # timestamp columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no timestamps
-        if isinstance(X, DenseData) or issparse(X):
+        if issparse(X):
             return self
         tmp_dataset = X
         # If numpy array, temporarily convert to pandas for easier and uniform timestamp handling
@@ -73,10 +68,9 @@ class CustomTimestampFeaturizer(BaseEstimator, TransformerMixin):
         since min timestamp in the training dataset.
 
         :param X: The dataset containing timestamp columns to featurize.
-        :type X: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type X: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The transformed dataset.
-        :rtype: numpy.array or iml.datatypes.DenseData or scipy.sparse.csr_matrix
+        :rtype: numpy.array or scipy.sparse.csr_matrix
         """
         tmp_dataset = X
         if len(self._time_col_names) > 0:
@@ -103,8 +97,7 @@ class DatasetWrapper(object):
 
     :param dataset: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type dataset: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     """
 
     def __init__(self, dataset, clear_references=False):
@@ -112,8 +105,7 @@ class DatasetWrapper(object):
 
         :param dataset: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type dataset: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param clear_references: A memory optimization that clears all references after use in explainers.
         :type clear_references: bool
         """
@@ -145,7 +137,7 @@ class DatasetWrapper(object):
         """Get the dataset.
 
         :return: The underlying dataset.
-        :rtype: numpy.array or iml.datatypes.DenseData or scipy.sparse.csr_matrix
+        :rtype: numpy.array or scipy.sparse.csr_matrix
         """
         return self._dataset
 
@@ -154,7 +146,7 @@ class DatasetWrapper(object):
         """Get the dataset in the original type, pandas DataFrame or Series.
 
         :return: The underlying dataset.
-        :rtype: numpy.array or pandas.DataFrame or pandas.Series or iml.datatypes.DenseData or scipy.sparse matrix
+        :rtype: numpy.array or pandas.DataFrame or pandas.Series or scipy.sparse matrix
         """
         wrapper_func = self.typed_wrapper_func
         return wrapper_func(self._dataset)
@@ -197,7 +189,7 @@ class DatasetWrapper(object):
         Note: if the original dataset was a pandas dataframe, this will return the numpy version.
 
         :return: The original dataset.
-        :rtype: numpy.array or iml.datatypes.DenseData or scipy.sparse matrix
+        :rtype: numpy.array or scipy.sparse matrix
         """
         return self._original_dataset
 
@@ -206,7 +198,7 @@ class DatasetWrapper(object):
         """Get the original typed dataset which could be a numpy array or pandas DataFrame or pandas Series.
 
         :return: The original dataset.
-        :rtype: numpy.array or pandas.DataFrame or pandas.Series or iml.datatypes.DenseData or scipy.sparse matrix
+        :rtype: numpy.array or pandas.DataFrame or pandas.Series or scipy.sparse matrix
         """
         return self._original_dataset_with_type
 
@@ -232,7 +224,7 @@ class DatasetWrapper(object):
         """Get the summary dataset without any subsetting.
 
         :return: The original dataset or None if summary was not computed.
-        :rtype: numpy.array or iml.datatypes.DenseData or scipy.sparse.csr_matrix
+        :rtype: numpy.array or scipy.sparse.csr_matrix
         """
         return self._summary_dataset
 
@@ -311,7 +303,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if isinstance(self._dataset, DenseData) or issparse(self._dataset):
+        if issparse(self._dataset):
             return None
         # If the user doesn't have a newer version of scikit-learn with OrdinalEncoder, don't do encoding
         try:
@@ -359,7 +351,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if not columns or isinstance(self._dataset, DenseData) or issparse(self._dataset):
+        if not columns or issparse(self._dataset):
             return None
         # If the user doesn't have a newer version of scikit-learn with OneHotEncoder, don't do encoding
         try:
@@ -387,7 +379,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if isinstance(self._dataset, DenseData) or issparse(self._dataset):
+        if issparse(self._dataset):
             return None
         typed_dataset_without_index = self.typed_wrapper_func(self._dataset, keep_index_as_feature=True)
         self._timestamp_featurizer = CustomTimestampFeaturizer(self._features).fit(typed_dataset_without_index)
@@ -479,11 +471,7 @@ class DatasetWrapper(object):
         # Edge case: Take the subset of the summary in this case,
         # more optimal than recomputing the summary!
         explain_subset = np.array(explain_subset)
-        if isinstance(self._dataset, DenseData):
-            group_names = np.array(self._dataset.group_names)[explain_subset].tolist()
-            self._dataset = DenseData(self._dataset.data[:, explain_subset], group_names)
-        else:
-            self._dataset = self._dataset[:, explain_subset]
+        self._dataset = self._dataset[:, explain_subset]
         self._subset_taken = True
 
     def _reduce_examples(self, max_dim_clustering=Defaults.MAX_DIM):

--- a/python/interpret_community/dataset/dataset_wrapper.py
+++ b/python/interpret_community/dataset/dataset_wrapper.py
@@ -48,7 +48,7 @@ class CustomTimestampFeaturizer(BaseEstimator, TransformerMixin):
         # If the data was previously successfully summarized, then there are no
         # timestamp columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no timestamps
-        if issparse(X):
+        if str(type(X)).endswith(".DenseData'>") or issparse(X):
             return self
         tmp_dataset = X
         # If numpy array, temporarily convert to pandas for easier and uniform timestamp handling
@@ -303,7 +303,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if issparse(self._dataset):
+        if str(type(self._dataset)).endswith(".DenseData'>") or issparse(self._dataset):
             return None
         # If the user doesn't have a newer version of scikit-learn with OrdinalEncoder, don't do encoding
         try:
@@ -351,7 +351,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if not columns or issparse(self._dataset):
+        if not columns or str(type(self._dataset)).endswith(".DenseData'>") or issparse(self._dataset):
             return None
         # If the user doesn't have a newer version of scikit-learn with OneHotEncoder, don't do encoding
         try:
@@ -379,7 +379,7 @@ class DatasetWrapper(object):
         # If the data was previously successfully summarized, then there are no
         # categorical columns as it must be numeric.
         # Also, if the dataset is sparse, we can assume there are no categorical strings
-        if issparse(self._dataset):
+        if str(type(self._dataset)).endswith(".DenseData'>") or issparse(self._dataset):
             return None
         typed_dataset_without_index = self.typed_wrapper_func(self._dataset, keep_index_as_feature=True)
         self._timestamp_featurizer = CustomTimestampFeaturizer(self._features).fit(typed_dataset_without_index)

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -14,10 +14,6 @@ from scipy.sparse import issparse
 
 from abc import ABC, abstractmethod
 
-try:
-    from shap.common import DenseData
-except ImportError:
-    from shap.utils._legacy import DenseData
 from interpret.utils import gen_local_selector, gen_global_selector, gen_name_from_class
 
 from ..common.explanation_utils import (_sort_values,
@@ -1289,8 +1285,6 @@ class _DatasetsMixin(object):
             return data.tolist()
         elif isinstance(data, pd.DataFrame):
             return data.values.tolist()
-        elif isinstance(data, DenseData):
-            return data.data
         else:
             # doesn't handle sparse or string right now
             return data
@@ -1819,9 +1813,6 @@ def save_explanation(explanation, path, exist_ok=False):
             elif isinstance(value, DatasetWrapper):
                 value = value.original_dataset.tolist()
                 metadata = 'DatasetWrapper'
-            elif isinstance(value, DenseData):
-                value = value.data
-                metadata = 'DenseData'
             elif isinstance(value, np.ndarray):
                 value = value.tolist()
                 metadata = 'ndarray'

--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -31,10 +31,6 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    try:
-        from shap.common import DenseData
-    except ImportError:
-        from shap.utils._legacy import DenseData
 
 
 @add_prepare_function_and_summary_method
@@ -51,8 +47,7 @@ class LIMEExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param is_function: Default set to false, set to True if passing function instead of model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -132,8 +127,7 @@ class LIMEExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param is_function: Default set to false, set to True if passing function instead of model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -227,8 +221,6 @@ class LIMEExplainer(BlackBoxExplainer):
         function, summary = self._prepare_function_and_summary(self.function, self.original_data_ref,
                                                                self.current_index_list, nclusters=nclusters,
                                                                explain_subset=explain_subset, **kwargs)
-        if isinstance(summary, DenseData):
-            summary = summary.data
         self._lime_feature_names = [str(i) for i in range(summary.shape[1])]
         result = function(summary[0].reshape((1, -1)))
         # If result is 2D array, this is classification scenario, otherwise regression

--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -221,6 +221,8 @@ class LIMEExplainer(BlackBoxExplainer):
         function, summary = self._prepare_function_and_summary(self.function, self.original_data_ref,
                                                                self.current_index_list, nclusters=nclusters,
                                                                explain_subset=explain_subset, **kwargs)
+        if str(type(summary)).endswith(".DenseData'>"):
+            summary = summary.data
         self._lime_feature_names = [str(i) for i in range(summary.shape[1])]
         result = function(summary[0].reshape((1, -1)))
         # If result is 2D array, this is classification scenario, otherwise regression

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -40,10 +40,6 @@ import warnings
 
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
-    try:
-        from shap.common import DenseData
-    except ImportError:
-        from shap.utils._legacy import DenseData
 
 
 class MimicExplainer(BlackBoxExplainer):
@@ -58,8 +54,7 @@ class MimicExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explainable_model: The uninitialized surrogate model used to explain the black box model.
         Also known as the student model.
     :type explainable_model: interpret_community.mimic.models.BaseExplainableModel
@@ -156,8 +151,7 @@ class MimicExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explainable_model: The uninitialized surrogate model used to explain the black box model.
             Also known as the student model.
         :type explainable_model: BaseExplainableModel
@@ -309,8 +303,6 @@ class MimicExplainer(BlackBoxExplainer):
         # Train the mimic model on the given model
         training_data = initialization_examples.dataset
         self.initialization_examples = initialization_examples
-        if isinstance(training_data, DenseData):
-            training_data = training_data.data
 
         explainable_model_args[ExplainParams.CLASSIFICATION] = self.predict_proba_flag
         if self._supports_shap_values_output(explainable_model):
@@ -745,8 +737,7 @@ class MimicExplainer(BlackBoxExplainer):
     def _get_surrogate_model_replication_measure(self, training_data):
         """Return the metric which tells how well the surrogate model replicates the teacher model.
         :param training_data: The data for getting the replication metric.
-        :type training_data: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type training_data: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Metric that tells how well the surrogate model replicates the behavior of teacher model.
         :rtype: float
         """

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -303,6 +303,8 @@ class MimicExplainer(BlackBoxExplainer):
         # Train the mimic model on the given model
         training_data = initialization_examples.dataset
         self.initialization_examples = initialization_examples
+        if str(type(training_data)).endswith(".DenseData'>"):
+            training_data = training_data.data
 
         explainable_model_args[ExplainParams.CLASSIFICATION] = self.predict_proba_flag
         if self._supports_shap_values_output(explainable_model):

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -141,7 +141,7 @@ def _compute_background_data(dataset):
     :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     """
     background = _summarize_data(dataset)
-    if hasattr(background, 'data'):
+    if str(type(background)).endswith(".DenseData'>"):
         background = background.data
     if not issparse(background) and len(background.shape) == 2:
         mean_shape = background.shape[1]

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -15,10 +15,6 @@ import warnings
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
     import shap
-    try:
-        from shap.common import DenseData
-    except ImportError:
-        from shap.utils._legacy import DenseData
 
 DEFAULT_RANDOM_STATE = 123
 FEATURE_DEPENDENCE = 'interventional'
@@ -145,7 +141,7 @@ def _compute_background_data(dataset):
     :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     """
     background = _summarize_data(dataset)
-    if isinstance(background, DenseData):
+    if hasattr(background, 'data'):
         background = background.data
     if not issparse(background) and len(background.shape) == 2:
         mean_shape = background.shape[1]

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -105,8 +105,7 @@ def _get_summary_data(initialization_examples, nclusters, framework):
 
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param nclusters: Number of means to use for approximation. A dataset is summarized with nclusters mean
         samples weighted by the number of data points they each represent. When the number of initialization
         examples is larger than (10 x nclusters), those examples will be summarized with k-means where
@@ -116,8 +115,7 @@ def _get_summary_data(initialization_examples, nclusters, framework):
     :type framework: str
     :return: A summarized matrix of feature vector examples (# examples x # features)
         for initializing the explainer.
-    :rtype: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix or torch.autograd.Variable
+    :rtype: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix or torch.autograd.Variable
     """
     initialization_examples.compute_summary(nclusters=nclusters)
     summary = initialization_examples.dataset
@@ -138,8 +136,7 @@ class DeepExplainer(StructuredInitModelExplainer):
     :type model: PyTorch or TensorFlow model
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation. The subset can be the top-k features
         from the model summary.
@@ -204,8 +201,7 @@ class DeepExplainer(StructuredInitModelExplainer):
         :type model: PyTorch or TensorFlow model
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation. The subset can be the top-k features
             from the model summary.

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -43,8 +43,7 @@ class KernelExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param is_function: Default is False. Set to True if passing function instead of a model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -126,8 +125,7 @@ class KernelExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param is_function: Default is False. Set to True if passing function instead of a model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -37,8 +37,7 @@ class LinearExplainer(StructuredInitModelExplainer):
     :type model: (coef, intercept) or sklearn.linear_model.*
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation. The subset can be the top-k features
         from the model summary.
@@ -94,8 +93,7 @@ class LinearExplainer(StructuredInitModelExplainer):
         :type model: (coef, intercept) or sklearn.linear_model.*
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation. The subset can be the top-k features
             from the model summary.

--- a/python/interpret_community/tabular_explainer.py
+++ b/python/interpret_community/tabular_explainer.py
@@ -29,8 +29,7 @@ class TabularExplainer(BaseExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-        scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
         process when number of features is large and the user already knows the set of interested
@@ -90,8 +89,7 @@ class TabularExplainer(BaseExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or iml.datatypes.DenseData or
-            scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation, which will speed up the explanation
             process when number of features is large and the user already knows the set of interested

--- a/test/test_serialize_explanation.py
+++ b/test/test_serialize_explanation.py
@@ -19,10 +19,6 @@ from common_utils import (create_sklearn_svm_classifier, create_sklearn_linear_r
 from constants import DatasetConstants
 from constants import owner_email_tools_and_ux
 from interpret_community.dataset.dataset_wrapper import DatasetWrapper
-try:
-    from shap.common import DenseData
-except ImportError:
-    from shap.utils._legacy import DenseData
 
 test_logger = logging.getLogger(__name__)
 
@@ -85,7 +81,7 @@ def _assert_explanation_equivalence(actual, expected):
         param = getattr(ExplainParams, paramkey)
         actual_value = getattr(actual, param, None)
         expected_value = getattr(expected, param, None)
-        if isinstance(actual_value, DatasetWrapper) or isinstance(actual_value, DenseData):
+        if isinstance(actual_value, DatasetWrapper):
             if isinstance(actual_value.original_dataset, np.ndarray):
                 actual_dataset = actual_value.original_dataset.tolist()
             else:


### PR DESCRIPTION
remove shap DenseData from supported input data
resolves issue: https://github.com/interpretml/interpret-community/issues/401

technically this is a breaking change, however shap github repo itself made this class private, so we are only following the precedent for this by removing support for it here