### PR TITLE
release interpret-community 0.18.0

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
-_minor = '17'
-_patch = '2'
+_minor = '18'
+_patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- upgrade shap to 0.39.0, which deprecated python 3.5 and added python 3.8 support
- Add cuML GPU SHAP KernelExplainer 
- update abstract classes to use ABC instead of ABCMeta
- remove warning on mimic explainer relating to categorical features
- Add test case of serializing pandas timestamp
- add sparse feature importance support for lightgbm surrogate model
- add support for drop parameter in one hot encoder
