### PR TITLE
implement sparse scenario for getting ranked values and indexes on local explanation

### DIFF
--- a/python/interpret_community/shap/gpu_kernel_explainer.py
+++ b/python/interpret_community/shap/gpu_kernel_explainer.py
@@ -35,7 +35,6 @@ from .kwargs_utils import _get_explain_global_kwargs
 from .._internal.raw_explain.raw_explain_utils import get_datamapper_and_transformed_data, \
     transform_with_datamapper
 
-import warnings
 try:
     import cuml
     if cuml.__version__ == '0.18.0':
@@ -45,9 +44,6 @@ try:
     rapids_installed = True
 except ImportError:
     rapids_installed = False
-    warnings.warn(
-        "cuML is required to use GPU explainers. Check https://rapids.ai/start.html \
-        for more information on how to install it.")
 
 
 @add_prepare_function_and_summary_method


### PR DESCRIPTION
for explanation methods:
get_ranked_local_values
get_ranked_local_names
get_local_importance_rank
implement missing sparse logic.  Also, compress local importance values to dense format based on whether it will be more optimal storage when converting an engineered explanation to a raw explanation.
Fix scores representation to be dense when passing to widget (otherwise ExplanationDashboard fails).
Also, removes another spurious cuML warning message on library import.
