### PR TITLE
release interpret-community 0.18.1

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
 _minor = '18'
-_patch = '0'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- includes fix to implement sparse case for methods:
  - get_ranked_local_values
  - get_ranked_local_names
  - get_local_importance_rank

and compress local importance values to dense format based on whether it will be more optimal storage when converting an engineered explanation to a raw explanation
- remove another spurious cuML warning message on library import.