### PR TITLE
Update cuML version for GPUKernelExplainer

### DIFF
--- a/notebooks/explain-binary-classification-local-gpu.ipynb
+++ b/notebooks/explain-binary-classification-local-gpu.ipynb
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "# Train a cuML model\n",
-    "clf = cuml.svm.SVC(gamma=0.001, C=100., probability=True)\n",
+    "cu_clf = cuml.svm.SVC(gamma=0.001, C=100., probability=True)\n",
     "model = cu_clf.fit(x_train, y_train)\n",
     "\n",
     "# Train sklearn model\n",
@@ -344,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/python/interpret_community/shap/gpu_kernel_explainer.py
+++ b/python/interpret_community/shap/gpu_kernel_explainer.py
@@ -39,7 +39,7 @@ try:
     import cuml
     if cuml.__version__ == '0.18.0':
         from cuml.experimental.explainer import KernelExplainer as cuml_Kernel_SHAP
-    elif cuml.__version__ == '0.19.0':
+    elif cuml.__version__ > '0.18.0':
         from cuml.explainer import KernelExplainer as cuml_Kernel_SHAP
     rapids_installed = True
 except ImportError:


### PR DESCRIPTION
PR changes the version check to accommodate all versions above 0.18, and fixes a typo in the notebook example