### PR TITLE
move viz requirements to end of environment install

### DIFF
--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -60,11 +60,6 @@ steps:
 
   - bash: |
       source activate  ${{parameters.condaEnv}} 
-      pip install -r requirements-vis.txt
-    displayName: Install vis required pip packages
-
-  - bash: |
-      source activate  ${{parameters.condaEnv}} 
       pip install -r requirements-test.txt
     displayName: Install test required pip packages
 

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -65,6 +65,11 @@ steps:
     wheelArtifactName: ${{parameters.wheelArtifactName}}
     condaEnv: ${{parameters.condaEnv}}
 
+- bash: |
+    source activate  ${{parameters.condaEnv}} 
+    pip install -r requirements-vis.txt
+  displayName: Install vis required pip packages
+
 - ${{ if eq(parameters.testRunType, 'Unit')}}:
   - bash: |
         source activate ${{parameters.condaEnv}}


### PR DESCRIPTION
Move visualization requirements to end of environment install.
The problem I was hitting was that the viz requirements would install the released version of interpret-community with older dependencies, so new dependencies would not get tested.  The viz requirements includes raiwidgets which depends on responsibleai package which depends on an older version of interpret-community.