### PR TITLE
release interpret-community 0.19.1

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
 _minor = '19'
-_patch = '0'
+_patch = '1'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- fix error when creating a raw explanation from an engineered explanation that does not have a DatasetsMixin