### PR TITLE
fix explanation dashboard failing to run on dataset with boolean target labels

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -518,7 +518,7 @@ class LocalExplanation(FeatureImportanceExplanation):
         di = {}
         di["actual"] = y[i]
         di["predicted"] = y_hat[i]
-        if isinstance(y[i], str) or isinstance(y_hat, str):
+        if any(isinstance(v, (str, bool, np.bool_)) for v in [y[i], y_hat[i]]):
             di["residual"] = int(y[i] == y_hat[i])
         else:
             di["residual"] = y[i] - y_hat[i]

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -411,6 +411,20 @@ def create_cancer_data():
     return x_train, x_test, y_train, y_validation, feature_names, target_names
 
 
+def create_cancer_data_booleans():
+    # Import cancer dataset
+    cancer = retrieve_dataset('breast-cancer.train.csv', na_values='?').interpolate().astype('int64')
+    cancer_target = cancer.iloc[:, 0]
+    cancer_data = cancer.iloc[:, 1:]
+    feature_names = cancer_data.columns.values
+    target_names = [False, True]
+    cancer_target = cancer_target.astype(bool)
+    # Split data into train and test
+    x_train, x_test, y_train, y_validation = train_test_split(cancer_data, cancer_target,
+                                                              test_size=0.2, random_state=0)
+    return x_train, x_test, y_train, y_validation, feature_names, target_names
+
+
 def create_scikit_cancer_data():
     breast_cancer_data = load_breast_cancer()
     classes = breast_cancer_data.target_names.tolist()

--- a/test/test_explanation_dashboard.py
+++ b/test/test_explanation_dashboard.py
@@ -13,7 +13,7 @@ from interpret_community.mimic.models.lightgbm_model import LGBMExplainableModel
 from interpret_community.common.constants import ModelTask
 from raiwidgets import ExplanationDashboard
 from common_utils import (create_lightgbm_classifier, create_sklearn_svm_classifier,
-                          create_cancer_data)
+                          create_cancer_data, create_cancer_data_booleans)
 
 from constants import owner_email_tools_and_ux
 
@@ -63,6 +63,16 @@ class TestExplanationDashboard:
     def test_local_explanation(self, mimic_explainer):
         # Validate visualizing ExplanationDashboard with a local explanation
         x_train, x_test, y_train, y_test, feature_names, target_names = create_cancer_data()
+        # Fit an SVM model
+        model = create_sklearn_svm_classifier(x_train, y_train)
+        explainer = mimic_explainer(model, x_train, LGBMExplainableModel,
+                                    features=feature_names, classes=target_names)
+        explanation = explainer.explain_local(x_test)
+        ExplanationDashboard(explanation, model, dataset=x_test, true_y=y_test)
+
+    def test_boolean_labels(self, mimic_explainer):
+        # Validate visualizing ExplanationDashboard with a local explanation
+        x_train, x_test, y_train, y_test, feature_names, target_names = create_cancer_data_booleans()
         # Fit an SVM model
         model = create_sklearn_svm_classifier(x_train, y_train)
         explainer = mimic_explainer(model, x_train, LGBMExplainableModel,


### PR DESCRIPTION
fixes issue:
https://github.com/interpretml/interpret-community/issues/429

the fix is to handle boolean labels in the _perf_dict method which is called when the dashboard gets the explanation data as a dictionary for visualization.  Previously, we would try to subtract the boolean values which would lead to an error:

```
TypeError: numpy boolean subtract, the - operator, is not supported, use the bitwise_xor, the ^ operator, or the logical_xor function instead.`
```

Instead, we should be checking for equality via == instead.

The PR includes both the fix for the issue and a test that was used to reproduce the problem.
