### PR TITLE
fix raw aggregated explanation failing to compute when transformations passed to mimic explainer and include_local=False

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1664,7 +1664,7 @@ def _get_local_explanation_row(explainer, evaluation_examples, i, batch_size):
     :return: The local explanation for the slice of rows.
     :rtype: DynamicLocalExplanation
     """
-    rows = evaluation_examples.dataset[i:i + batch_size]
+    rows = evaluation_examples.typed_wrapper_func(evaluation_examples.dataset[i:i + batch_size])
     return explainer.explain_local(rows)
 
 

--- a/test/transformation_utils.py
+++ b/test/transformation_utils.py
@@ -1,0 +1,80 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+# Common utilities for transformations used by tests
+
+import numpy as np
+import pandas as pd
+
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import FunctionTransformer, StandardScaler
+from sklearn.pipeline import Pipeline
+
+from raw_explain.utils import IdentityTransformer
+
+
+def get_transformations_one_to_many_smaller(feature_names):
+    # results in number of features smaller than original features
+    transformations = []
+    # Take out last feature after taking a copy
+    feature_names = list(feature_names)
+    feature_names.pop()
+
+    index = 0
+    for f in feature_names:
+        transformations.append(("{}".format(index), "passthrough", [f]))
+        index += 1
+
+    return ColumnTransformer(transformations)
+
+
+def get_transformations_one_to_many_greater(feature_names):
+    # results in number of features greater than original features
+    # copy all features except last one. For last one, replicate columns to create 3 more features
+    transformations = []
+    feature_names = list(feature_names)
+    index = 0
+    for f in feature_names[:-1]:
+        transformations.append(("{}".format(index), "passthrough", [f]))
+        index += 1
+
+    def copy_func(x):
+        return np.tile(x, (1, 3))
+
+    copy_transformer = FunctionTransformer(copy_func)
+
+    transformations.append(("copy_transformer", copy_transformer, [feature_names[-1]]))
+
+    return ColumnTransformer(transformations)
+
+
+def get_transformations_many_to_many(feature_names):
+    # Instantiate data mapper with many to many transformer support and test whether the feature map is generated
+
+    # IdentityTransformer is our custom transformer, so not recognized as one to many
+    transformations = [
+        ("column_0_1_2_3", Pipeline([
+            ("scaler", StandardScaler()),
+            ("identity", IdentityTransformer())]), [f for f in feature_names[:-2]]),
+        ("column_4_5", StandardScaler(), [f for f in feature_names[-2:]])
+    ]
+
+    # add transformations with pandas index types
+    transformations.append(("pandas_index_columns", "passthrough",
+                            pd.Index([feature_names[0], feature_names[1]])))
+
+    column_transformer = ColumnTransformer(transformations)
+
+    return column_transformer
+
+
+def get_transformations_from_col_transformer(col_transformer):
+    transformers = []
+    for name, tr, column_name, in col_transformer.transformers_:
+        if tr == "passthrough":
+            tr = None
+        if tr != "drop":
+            transformers.append((column_name, tr))
+
+    return transformers


### PR DESCRIPTION
When computing a raw explanation by passing in the transformations object to mimic explainer, instead of computing the explanation and then using a feature map, if include_local=False and no local importance values are computed the resulting explanation computation will error out.  This is because the code will try to transform the explanation to raw from engineered, but when aggregating the local importance values have already been computed as raw and mapped in the explain_local method.  The most correct way to handle this is to prevent the second transformation from being done, since the aggregated explanation is already in terms of raw importances and the transformation is not needed.