### PR TITLE
release interpret-community 0.20.0

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
-_minor = '19'
-_patch = '3'
+_minor = '20'
+_patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- Removed old ExplanationDashboard.  The old namespace still exists but widget won't display anything and will print a warning now.  Please use the ExplanationDashboard from the raiwidgets package instead.

  Please install raiwidgets from pypi by running:

  ```pip install --upgrade raiwidgets```

  The dashboard can be run with the same parameters in the new namespace:

  ```from raiwidgets import ExplanationDashboard```

  For more information on the new widget please see: https://github.com/microsoft/responsible-ai-widgets

- Fixed raw aggregated explanation failing to compute when transformations passed to mimic explainer and include_local=False