### PR TITLE
change explainers tabular explainer runs based on use_gpu flag

### DIFF
--- a/test/test_explain_model.py
+++ b/test/test_explain_model.py
@@ -20,6 +20,9 @@ from common_utils import (create_sklearn_random_forest_classifier, create_sklear
                           create_msx_data, wrap_classifier_without_proba)
 from raw_explain.utils import _get_feature_map_from_indices_list
 from interpret_community.common.constants import ModelTask
+from interpret_community.tabular_explainer import _get_uninitialized_explainers
+from interpret_community.shap import (KernelExplainer, LinearExplainer, DeepExplainer, TreeExplainer,
+                                      GPUKernelExplainer)
 from constants import DatasetConstants
 
 from sklearn.model_selection import train_test_split
@@ -748,6 +751,12 @@ class TestTabularExplainer(object):
         explanation = exp.explain_global(x_test)
         # Validate predicted y values are boolean
         assert(np.all(np.isin(explanation.eval_y_predicted, [0, 1])))
+
+    def test_tabular_explainer_get_explainers(self):
+        non_gpu_explainers = _get_uninitialized_explainers(use_gpu=False)
+        assert non_gpu_explainers == [TreeExplainer, DeepExplainer, LinearExplainer, KernelExplainer]
+        gpu_explainers = _get_uninitialized_explainers(use_gpu=True)
+        assert gpu_explainers == [GPUKernelExplainer]
 
     def verify_adult_overall_features(self, ranked_global_names, ranked_global_values):
         # Verify order of features


### PR DESCRIPTION
- Based on experience of debugging with customer, when TabularExplainer fails with default use_gpu=False on GPUKernelExplainer it prints the last warning, even though it will always fail.  This PR separates it out so it only runs when use_gpu flag is on.  The previous logic would skip every explainer if use_gpu=True other than GPUKernelExplainer, but still for some reason run it even if use_gpu=False.  By separating it out, the customer will once again see the most useful error message from the last default catch-all KernelExplainer.