### PR TITLE
fix model wrapper to handle a pytorch binary classification model that only outputs probabilities for positive class

### DIFF
--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -171,7 +171,12 @@ class WrappedPytorchModel(object):
             dataset = dataset.values
         wrapped_dataset = torch.Tensor(dataset)
         with torch.no_grad():
-            result = torch.max(self._model(wrapped_dataset), 1)[1].numpy()
+            result = self._model(wrapped_dataset)
+        result_len = len(result.shape)
+        if result_len == 1 or (result_len > 1 and result.shape[1] == 1):
+            result = np.where(result.numpy() > 0.5, 1, 0)
+        else:
+            result = torch.max(result, 1)[1].numpy()
         # Reshape to 2D if output is 1D and input has one row
         if len(dataset.shape) == 1:
             result = result.reshape(1, -1)

--- a/test/common_utils.py
+++ b/test/common_utils.py
@@ -261,9 +261,7 @@ def _common_pytorch_generator(numCols, numClasses=None):
             X = F.relu(self.fc1(X))
             X = self.fc2(X)
             X = self.fc3(X)
-            X = self.output(X)
-
-            return X
+            return self.output(X)
     return Net()
 
 
@@ -321,6 +319,33 @@ def create_pytorch_classifier(X, y):
     criterion = nn.CrossEntropyLoss()
     optimizer = torch.optim.SGD(net.parameters(), lr=0.01)
     return _train_pytorch_model(epochs, criterion, optimizer, net, torch_X, torch_y)
+
+
+def create_pytorch_single_output_classifier(X, y):
+    # create simple (dummy) Pytorch DNN model for binary classification that only outputs
+    # the probabilities for the positive class
+    epochs = 100
+    torch_X = torch.Tensor(X).float()
+    torch_y = torch.Tensor(y).float()
+
+    class Net(nn.Module):
+        def __init__(self, input_shape):
+            super(Net, self).__init__()
+            self.fc1 = nn.Linear(input_shape, 32)
+            self.fc2 = nn.Linear(32, 64)
+            self.fc3 = nn.Linear(64, 1)
+
+        def forward(self, X):
+            X = torch.relu(self.fc1(X))
+            X = torch.relu(self.fc2(X))
+            return torch.sigmoid(self.fc3(X))
+
+    # Create network structure
+    net = Net(X.shape[1])
+    # Train the model
+    criterion = nn.BCELoss()
+    optimizer = torch.optim.SGD(net.parameters(), lr=0.01)
+    return _train_pytorch_model(epochs, criterion, optimizer, net, torch_X, torch_y.reshape(-1, 1))
 
 
 def create_keras_multiclass_classifier(X, y):

--- a/test/test_explain_model.py
+++ b/test/test_explain_model.py
@@ -17,7 +17,8 @@ from common_utils import (create_sklearn_random_forest_classifier, create_sklear
                           create_sklearn_random_forest_regressor, create_sklearn_linear_regressor,
                           create_keras_classifier, create_keras_regressor, create_lightgbm_classifier,
                           create_pytorch_classifier, create_pytorch_regressor, create_xgboost_classifier,
-                          create_msx_data, wrap_classifier_without_proba)
+                          create_msx_data, wrap_classifier_without_proba,
+                          create_pytorch_single_output_classifier)
 from raw_explain.utils import _get_feature_map_from_indices_list
 from interpret_community.common.constants import ModelTask
 from interpret_community.tabular_explainer import _get_uninitialized_explainers
@@ -398,6 +399,14 @@ class TestTabularExplainer(object):
         # Fit a pytorch DNN model
         model = create_pytorch_classifier(x_train.values, y_train)
         test_logger.info('Running explain global for test_explain_model_pytorch')
+        self._explain_model_dnn_common(tabular_explainer, model, x_train, x_test, y_train, X.columns.values)
+
+    def test_explain_model_pytorch_binary_single_output(self, tabular_explainer):
+        X, y = shap.datasets.adult()
+        x_train, x_test, y_train, _ = train_test_split(X, y, test_size=0.2, random_state=7)
+        # Fit a pytorch DNN model
+        model = create_pytorch_single_output_classifier(x_train.values, y_train)
+        test_logger.info('Running explain global for test_explain_model_pytorch_binary_single_output')
         self._explain_model_dnn_common(tabular_explainer, model, x_train, x_test, y_train, X.columns.values)
 
     def test_explain_model_random_forest_regression(self, boston, tabular_explainer):


### PR DESCRIPTION
Fixes a customer issue where model_wrapper was giving all zero probabilities for a pytorch binary classification model (note not errors) that only output the probabilities for the positive class.  Calling torch.max(probabilites, 1) was giving zero values since the output was 1-dimensional anyway.  Instead of calling torch.max, we should just threshold the values.