### PR TITLE
add an explanation adapter to integrate our explanations with other frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Pytorch installation if desired:
 
 lightgbm installation if desired:
 ```
-    conda install --yes -c conda-forge lightgbm
+    pip install --upgrade lightgbm
 ```
 
 </details>
@@ -127,7 +127,7 @@ Pytorch installation if desired:
 
 lightgbm installation if desired:
 ```
-    conda install --yes -c conda-forge lightgbm
+    pip install --upgrade lightgbm
 ```
 </details>
 
@@ -142,7 +142,7 @@ Pytorch installation if desired:
 lightgbm installation if desired (requires Homebrew):
 ```
     brew install libomp
-    conda install --yes -c conda-forge lightgbm
+    pip install --upgrade lightgbm
 ```
 
 If installing the package generally gives an error about the `certifi` package, run this first:

--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -23,22 +23,22 @@ steps:
 
   - bash: |
       source activate ${{parameters.condaEnv}}
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} numpy==1.18.5
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch-cpu torchvision-cpu -c pytorch
-      conda install --yes -c anaconda -n  ${{parameters.condaEnv}} jupyter pip
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} numpy==1.20.3
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision captum cpuonly -c pytorch
     displayName: Install Anaconda packages
+    condition:  ne(variables['Agent.OS'], 'Darwin')
+
+  - bash: |
+      source activate ${{parameters.condaEnv}}
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} numpy==1.20.3
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision captum -c pytorch
+    displayName: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
+    condition:  eq(variables['Agent.OS'], 'Darwin')
 
   - bash: |
       source activate  ${{parameters.condaEnv}}
       conda install --yes -c conda-forge lightgbm
     displayName: Install lightgbm from conda on MacOS
-    condition:  eq(variables['Agent.OS'], 'Darwin')
-
-  - bash: |
-      source activate ${{parameters.condaEnv}}
-      pip install torch
-      pip install torchvision
-    displayName: Install torch from pip on MacOS
     condition:  eq(variables['Agent.OS'], 'Darwin')
 
   - bash: |
@@ -60,6 +60,11 @@ steps:
 
   - bash: |
       source activate  ${{parameters.condaEnv}} 
+      pip install --upgrade jupyter
+    displayName: Install jupyter
+
+  - bash: |
+      source activate  ${{parameters.condaEnv}} 
       pip install -r requirements-test.txt
     displayName: Install test required pip packages
 
@@ -75,7 +80,7 @@ steps:
 
   - bash: |
       source activate  ${{parameters.condaEnv}} 
-      conda install --yes -c conda-forge -n ${{parameters.condaEnv}} papermill 
+      pip install papermill
       pip install scrapbook
     displayName: List Jupyter Kernel and fix
 

--- a/notebooks/captum-integration-example.ipynb
+++ b/notebooks/captum-integration-example.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copyright (c) Microsoft Corporation. All rights reserved.\n",
+    "\n",
+    "Licensed under the MIT License."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example of integration with pytorch/captum\n",
+    "_**This notebook showcases how create an interpret-community style explanation using captum to view it in the dashboard.**_\n",
+    "\n",
+    "\n",
+    "## Table of Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "1. [Setup](#Setup)\n",
+    "1. [Project](#Project)\n",
+    "1. [Run model explainer locally at training time](#Explain)\n",
+    "    1. Train a binary classification model\n",
+    "    1. Explain the model\n",
+    "        1. Generate global explanations\n",
+    "        1. Generate local explanations\n",
+    "1. [Visualize results](#Visualize)\n",
+    "1. [Next steps](#Next)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Introduction'></a>\n",
+    "## 1. Introduction\n",
+    "\n",
+    "This notebook illustrates how to integrate captum explanations with intepret-community visualization.\n",
+    "\n",
+    "<a id='Project'></a>       \n",
+    "## 2. Project\n",
+    "\n",
+    "The goal of this project is to run an IntegratedGradients explainer from captum and visualize it in the ExplanationDashboard.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Explain'></a>\n",
+    "## 3. Create a captum model (taken from their main page)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example taken from captum's main page\n",
+    "# https://captum.ai/\n",
+    "import numpy as np\n",
+    "\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "\n",
+    "from captum.attr import IntegratedGradients\n",
+    "\n",
+    "class ToyModel(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.lin1 = nn.Linear(3, 3)\n",
+    "        self.relu = nn.ReLU()\n",
+    "        self.lin2 = nn.Linear(3, 2)\n",
+    "        self.output = nn.Linear(2, 1)\n",
+    "\n",
+    "        # initialize weights and biases\n",
+    "        self.lin1.weight = nn.Parameter(torch.arange(-4.0, 5.0).view(3, 3))\n",
+    "        self.lin1.bias = nn.Parameter(torch.zeros(1,3))\n",
+    "        self.lin2.weight = nn.Parameter(torch.arange(-3.0, 3.0).view(2, 3))\n",
+    "        self.lin2.bias = nn.Parameter(torch.ones(1,2))\n",
+    "\n",
+    "    def forward(self, input):\n",
+    "        return self.output(self.lin2(self.relu(self.lin1(input))))\n",
+    "\n",
+    "\n",
+    "model = ToyModel()\n",
+    "model.eval()\n",
+    "\n",
+    "# Fix the random seed to make computations deterministic\n",
+    "\n",
+    "torch.manual_seed(123)\n",
+    "np.random.seed(123)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define input and baseline tensors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input = torch.rand(100, 3)\n",
+    "baseline = torch.zeros(100, 3)\n",
+    "labels = np.random.rand(100)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run integrated gradients to get an explanation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ig = IntegratedGradients(model)\n",
+    "attributions, delta = ig.attribute(input, baseline, target=0, return_convergence_delta=True)\n",
+    "# optionally print feature attributions\n",
+    "# print('IG Attributions:', attributions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create an interpret-community style explanation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from interpret_community.adapter import ExplanationAdapter\n",
+    "adapter = ExplanationAdapter(features=['A', 'B', 'C'])\n",
+    "global_explanation = adapter.create_global(attributions, evaluation_examples=np.array(input))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sorted SHAP values\n",
+    "print('ranked global importance values: {}'.format(global_explanation.get_ranked_global_values()))\n",
+    "# Corresponding feature names\n",
+    "print('ranked global importance names: {}'.format(global_explanation.get_ranked_global_names()))\n",
+    "# Feature ranks (based on original order of features)\n",
+    "print('global importance rank: {}'.format(global_explanation.global_importance_rank))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print out a dictionary that holds the sorted feature importance names and values\n",
+    "print('global importance rank: {}'.format(global_explanation.get_feature_importance_dict()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Explain overall model predictions as a collection of local (instance-level) explanations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# feature shap values for all features and all data points in the training data\n",
+    "# uncomment to view all local importance values:\n",
+    "# print('local importance values: {}'.format(global_explanation.local_importance_values))\n",
+    "\n",
+    "# view ranked local importance values for the first row:\n",
+    "sorted_local_importance_values = global_explanation.get_ranked_local_values()[0]\n",
+    "sorted_local_importance_names = global_explanation.get_ranked_local_names()[0]\n",
+    "\n",
+    "print('local importance values: {}'.format(sorted_local_importance_values))\n",
+    "print('local importance names: {}'.format(sorted_local_importance_names))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Visualize'></a>\n",
+    "## 4. Visualize\n",
+    "Load the visualization dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from raiwidgets import ExplanationDashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from interpret_community.common.model_wrapper import wrap_model\n",
+    "from interpret_community.dataset.dataset_wrapper import DatasetWrapper\n",
+    "import pandas as pd\n",
+    "wrapped_model = wrap_model(model, DatasetWrapper(input), model_task='regression')\n",
+    "dataset = pd.DataFrame(np.array(input))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ExplanationDashboard(global_explanation, wrapped_model, dataset=dataset, true_y=labels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Next'></a>\n",
+    "## 6. Next steps\n",
+    "Learn about other use cases of the explain package on a:\n",
+    "       \n",
+    "1. [Training time: regression problem](./explain-regression-local.ipynb)\n",
+    "1. [Training time: multiclass classification problem](./explain-multiclass-classification-local.ipynb)\n",
+    "1. Explain models with engineered features:\n",
+    "    1. [Simple feature transformations](./simple-feature-transformations-explain-local.ipynb)\n",
+    "    1. [Advanced feature transformations](./advanced-feature-transformations-explain-local.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "authors": [
+   {
+    "name": "ilmat"
+   }
+  ],
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/python/interpret_community/adapter/__init__.py
+++ b/python/interpret_community/adapter/__init__.py
@@ -1,0 +1,9 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines adapters for converting feature importance values to an explanation."""
+
+from .explanation_adapter import ExplanationAdapter
+
+__all__ = ["ExplanationAdapter"]

--- a/python/interpret_community/adapter/explanation_adapter.py
+++ b/python/interpret_community/adapter/explanation_adapter.py
@@ -1,0 +1,107 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Defines an adapter for creating an interpret-community style explanation from other frameworks."""
+
+import numpy as np
+
+from interpret_community.explanation.explanation import (
+    ExpectedValuesMixin, _create_local_explanation, _create_global_explanation,
+    _aggregate_global_from_local_explanation, _aggregate_streamed_local_explanations)
+from interpret_community.common.constants import ExplainParams, ExplainType, Defaults, ModelTask
+
+
+class ExplanationAdapter(object):
+    """An adapter for creating an interpret-community explanation from local importance values.
+
+    :param features: A list of feature names.
+    :type features: list[str]
+    :param classification: Indicates if this is a classification or regression explanation.
+    :type classification: bool
+    :param method: The explanation method used to explain the model (e.g., SHAP, LIME).
+    :type method: str
+    """
+
+    def __init__(self, features=None, classification=False, method='Adapter'):
+        """Create the explanation adapter.
+
+        :param features: A list of feature names.
+        :type features: list[str]
+        :param classification: Indicates if this is a classification or regression explanation.
+        :type classification: bool
+        :param method: The explanation method used to explain the model (e.g., SHAP, LIME).
+        :type method: str
+        """
+        self.classification = classification
+        self.features = features
+        self.method = method
+
+    def create_local(self, local_importance_values, evaluation_examples=None, expected_values=None):
+        """Create a local explanation from the list of local feature importance values.
+
+        :param local_importance_values: The feature importance values.
+        :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+        :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
+            to explain the model's output.
+        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :param expected_values: The expected values of the model.
+        :type expected_values: numpy.array
+        """
+        local_importance_values = np.array(local_importance_values)
+        # handle the case that the local importance values have a 2d shape for classification scenario
+        # and only specify the positive class
+        if len(local_importance_values.shape) == 2 and self.classification:
+            local_importance_values = np.array([-local_importance_values, local_importance_values])
+
+        kwargs = {ExplainParams.METHOD: self.method}
+        kwargs[ExplainParams.FEATURES] = self.features
+        if self.classification:
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
+        else:
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
+        kwargs[ExplainParams.LOCAL_IMPORTANCE_VALUES] = local_importance_values
+        kwargs[ExplainParams.EXPECTED_VALUES] = expected_values
+        kwargs[ExplainParams.CLASSIFICATION] = self.classification
+        if evaluation_examples is not None:
+            kwargs[ExplainParams.EVAL_DATA] = evaluation_examples
+        return _create_local_explanation(**kwargs)
+
+    def create_global(self, local_importance_values, evaluation_examples=None, expected_values=None,
+                      include_local=True, batch_size=Defaults.DEFAULT_BATCH_SIZE):
+        """Create a global explanation from the list of local feature importance values.
+
+        :param local_importance_values: The feature importance values.
+        :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+        :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
+            to explain the model's output.
+        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :param expected_values: The expected values of the model.
+        :type expected_values: numpy.array
+        :param include_local: Include the local explanations in the returned global explanation.
+            If include_local is False, will stream the local explanations to aggregate to global.
+        :type include_local: bool
+        :param batch_size: If include_local is False, specifies the batch size for aggregating
+            local explanations to global.
+        :type batch_size: int
+        """
+        local_explanation = self.create_local(local_importance_values, evaluation_examples, expected_values)
+        kwargs = {ExplainParams.METHOD: self.method}
+        kwargs[ExplainParams.FEATURES] = self.features
+        if ExpectedValuesMixin._does_quack(local_explanation):
+            kwargs[ExplainParams.EXPECTED_VALUES] = local_explanation.expected_values
+        if include_local:
+            kwargs[ExplainParams.LOCAL_EXPLANATION] = local_explanation
+            # Aggregate local explanation to global
+            return _aggregate_global_from_local_explanation(**kwargs)
+        else:
+            if ExplainParams.CLASSIFICATION in kwargs:
+                if kwargs[ExplainParams.CLASSIFICATION]:
+                    model_task = ModelTask.Classification
+                else:
+                    model_task = ModelTask.Regression
+            else:
+                model_task = ModelTask.Unknown
+            kwargs = _aggregate_streamed_local_explanations(self, evaluation_examples, model_task,
+                                                            self.features, batch_size, **kwargs)
+            return _create_global_explanation(**kwargs)

--- a/python/interpret_community/common/model_wrapper.py
+++ b/python/interpret_community/common/model_wrapper.py
@@ -310,7 +310,7 @@ def wrap_model(model, examples, model_task):
     :return: The wrapper model.
     :rtype: model
     """
-    return _wrap_model(model, examples, model_task, False)
+    return _wrap_model(model, examples, model_task, False)[0]
 
 
 def _wrap_model(model, examples, model_task, is_function):

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -840,7 +840,10 @@ class GlobalExplanation(FeatureImportanceExplanation):
                 mli_data = parent_data[InterpretData.MLI]
                 for local_mli_data in mli_data:
                     if local_mli_data[InterpretData.EXPLANATION_TYPE] == InterpretData.LOCAL_FEATURE_IMPORTANCE:
-                        local_mli_data[InterpretData.VALUE][InterpretData.INTERCEPT] = self.expected_values
+                        expected_values = None
+                        if ExpectedValuesMixin._does_quack(self):
+                            expected_values = self.expected_values
+                        local_mli_data[InterpretData.VALUE][InterpretData.INTERCEPT] = expected_values
                 mli_global_entry = {
                     InterpretData.EXPLANATION_TYPE: InterpretData.GLOBAL_FEATURE_IMPORTANCE,
                     InterpretData.VALUE: {

--- a/test/test_notebooks.py
+++ b/test/test_notebooks.py
@@ -101,3 +101,16 @@ def test_simple_feature_transformations_explain_local():
     pm.execute_notebook(processed_notebook, output_notebook)
     nb = sb.read_notebook(output_notebook)
     assert 'TotalWorkingYears' in nb.scraps.data_dict[SORTED_LOCAL_IMPORTANCE_NAMES][0]
+
+
+@pytest.mark.notebooks
+def test_captum_integration_example():
+    notebookname = 'captum-integration-example'
+    input_notebook = input_notebook_path(notebookname)
+    output_notebook = output_notebook_path(notebookname)
+    processed_notebook = processed_notebook_path(notebookname)
+    test_values = {SORTED_LOCAL_IMPORTANCE_NAMES: SORTED_LOCAL_IMPORTANCE_NAMES}
+    append_scrapbook_commands(input_notebook, processed_notebook, test_values)
+    pm.execute_notebook(processed_notebook, output_notebook)
+    nb = sb.read_notebook(output_notebook)
+    assert 'B' in nb.scraps.data_dict[SORTED_LOCAL_IMPORTANCE_NAMES]


### PR DESCRIPTION
- adds an adapter to convert any feature importance values to an explanation
- this PR is based on a previous PR: https://github.com/interpretml/interpret-community/pull/247
- includes a sample notebook to demonstate how a captum explanation can be viewed, but this can work with any feature importance values, including those from shap and lime