### PR TITLE
release interpret-community 0.21.0

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -23,6 +23,7 @@ Highlights of the package include:
 - The PFIExplainer can quickly compute global importance values
 - LIMEExplainer builds local linear approximations of the model's behavior by perturbing each instance
 - GPUKernelExplainer is GPU-accelerated implementation of SHAP's KernelExplainer as a part of RAPIDS's cuML library, and is optimized for GPU models, like those in cuML. It can be used with CPU-based estimators too.
+- An adapter to convert any feature importance values to an interpret-community style explanation
 
 Please see the github website for the documentation and sample notebooks:
 https://github.com/interpretml/interpret-community

--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
-_minor = '20'
+_minor = '21'
 _patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
 - add an explanation adapter to integrate our explanations with other frameworks 
 - update interpret-community to interpret-core 0.2.6
 - change explainers tabular explainer runs based on gpu flag
 - fix model wrapper to handle a pytorch binary classification model that only outputs probabilities for positive class
 - add test for old explanation dashboard and interpret dashboard

BREAKING CHANGE: function wrap_model now just returns the wrapped model