### PR TITLE
fix nightly build breaking due to new scikit-learn package which breaks model function serialization

### DIFF
--- a/test/test_serialize_explainer.py
+++ b/test/test_serialize_explainer.py
@@ -47,7 +47,7 @@ class TestSerializeExplainer(object):
         with open(explainer_name, 'wb') as stream:
             dump(explainer.explainer.explainer, stream)
         with open(model_name, 'wb') as stream:
-            dump(explainer.model.predict_proba, stream)
+            dump(explainer.model, stream)
         assert path.exists(model_name)
         assert path.exists(explainer_name)
 
@@ -69,7 +69,7 @@ class TestSerializeExplainer(object):
         surrogate_name = 'surrogate_model.joblib'
         tree_explainer_name = 'tree_explainer_model.joblib'
         with open(model_name, 'wb') as stream:
-            dump(explainer.model.predict_proba, stream)
+            dump(explainer.model, stream)
         with open(surrogate_name, 'wb') as stream:
             dump(explainer.surrogate_model.model, stream)
         with open(tree_explainer_name, 'wb') as stream:


### PR DESCRIPTION
A new release of scikit-learn no longer allows predict_proba function to be serializable directly due to error:

```
_pickle.PicklingError: Can't pickle <function BaseSVC.predict_proba at 0x000001F3460AAEE8>: it's not the same object as sklearn.svm._base.BaseSVC.predict_proba
```

This is causing our nightly builds to fail on our serialization unit tests, which use the newest version of scikit-learn on later python versions.
The fix is to make the model wrappers a bit more complex, and avoid serializing the function if possible.  However, note we try to keep the model wrappers backwards compatible still since they are public APIs.