### PR TITLE
version bump for shap 0.40.0 and interpret-core 0.2.7

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -42,8 +42,8 @@ DEPENDENCIES = [
     'scipy',
     'scikit-learn',
     'packaging',
-    'interpret-core[required]>=0.1.20, <=0.2.6',
-    'shap>=0.20.0, <=0.39.0'
+    'interpret-core[required]>=0.1.20, <=0.2.7',
+    'shap>=0.20.0, <=0.40.0'
 ]
 
 EXTRAS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ scikit-learn
 numpy
 pandas
 scipy==1.3.3
-interpret-core[required]>=0.1.20, <=0.2.6
+interpret-core[required]>=0.1.20, <=0.2.7
 shap>=0.20.0, <=0.40.0
 lime>=0.2.0.0


### PR DESCRIPTION
- bump shap version upper bound to 0.40.0
- bump interpret-core version upper bound to 0.2.7