### PR TITLE
release interpret-community 0.22.0

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
-_minor = '21'
+_minor = '22'
 _patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- version bump for shap 0.40.0 and interpret-core 0.2.7
- removed the pin on lightgbm package due to recent build break with new lightgbm release 3.3.1 and fixed the serialization logic to handle the new lightgbm model version
- upgraded tensorflow and xgboost test dependencies
- added support for keras scikit classifier and regressor to model wrapper
- fixed nightly build breaking due to new scikit-learn package which breaks model function serialization