### PR TITLE
add more dependencies to docs build to fix warnings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.9"
+    python: "3.8"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"
@@ -27,6 +27,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
+   - requirements: requirements.txt
    - requirements: requirements-doc.txt
 
 # Build PDF & ePub


### PR DESCRIPTION
fixes warnings about pandas and other libraries in the docs build, which was causing some documentation to not be built