### PR TITLE
remove numba dependency pin

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -37,7 +37,6 @@ CLASSIFIERS = [
 
 DEPENDENCIES = [
     'numpy',
-    'numba<0.54.0',
     'pandas',
     'scipy',
     'scikit-learn',


### PR DESCRIPTION
Removing the pin for numba<0.54.0.  This pin does not belong in interpret-community package.  Downstream users will need to make sure that if they are using latest numpy, they use numba>=0.54.0, and for some older versions of numpy (not sure what the exact threshold is) they will need to pin numba<0.54.0.