### PR TITLE
Fix multiple save()/load() bug

### DIFF
--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1866,7 +1866,7 @@ def _get_value_from_file(file_var):
     if meta == 'DataFrame':
         return pd.DataFrame(data)
     elif meta == 'DatasetWrapper':
-        return DatasetWrapper(data)
+        return DatasetWrapper(np.array(data))
     elif meta == 'ndarray':
         return np.array(data)
     elif meta == 'list':

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -1866,7 +1866,9 @@ def _get_value_from_file(file_var):
     if meta == 'DataFrame':
         return pd.DataFrame(data)
     elif meta == 'DatasetWrapper':
-        return DatasetWrapper(np.array(data))
+        if isinstance(data, list):
+            data = np.array(data)
+        return DatasetWrapper(data)
     elif meta == 'ndarray':
         return np.array(data)
     elif meta == 'list':


### PR DESCRIPTION
The problem ocurrs in the scenario when saved explanations are loaded from disk and saved again. This leads to inconsistent types for init_data where the init_data type is changed from numpy arrays to list. This causes the following problem on a save_explanations()

    def save_explanation(explanation, path, exist_ok=False):
        """Serialize the explanation.

        :param explanation: The Explanation to be serialized.
        :type explanation: Explanation
        :param path: The path to the directory in which the explanation will be saved. By default, must be a new directory
            to avoid overwriting any previous explanations. Set exist_ok to True to overrule this behavior.
        :type path: str
        :param exist_ok: If False (default), the path provided by the user must not already exist and will be created by
            this function. If True, a prexisting path may be passed. Any preexisting files whose names match those of the
            files that make up the explanation will be overwritten.
        :type exist_ok: bool
        :return: JSON-formatted explanation data.
        :rtype: str
        """
        if os.path.exists(path) and not exist_ok:
            raise Exception('The directory specified by path already exists. '
                            'Please pass in a new directory or set exists_ok=True.')
        os.makedirs(path, exist_ok=True)

        # TODO replace with set of params from below
        uploadable_properties = [
            ExplainParams.FEATURES,
            ExplainParams.LOCAL_IMPORTANCE_VALUES,
            ExplainParams.EXPECTED_VALUES,
            ExplainParams.CLASSES,
            ExplainParams.GLOBAL_IMPORTANCE_NAMES,
            ExplainParams.GLOBAL_IMPORTANCE_RANK,
            ExplainParams.GLOBAL_IMPORTANCE_VALUES,
            ExplainParams.PER_CLASS_NAMES,
            ExplainParams.PER_CLASS_RANK,
            ExplainParams.PER_CLASS_VALUES,
            ExplainParams.INIT_DATA,
            ExplainParams.EVAL_DATA,
            ExplainParams.EVAL_Y_PRED,
            ExplainParams.EVAL_Y_PRED_PROBA
        ]
        import pdb
        # TODO will need to add viz data on top of this
        for prop in uploadable_properties:
            if prop == ExplainParams.INIT_DATA:
                pdb.set_trace()
>           if prop == ExplainParams.EVAL_DATA:
E           AttributeError: 'list' object has no attribute 'tolist'

The fix is address the type to numpy array when initializing the DatasetWrapper object in _get_value_from_file().

Also added a test case to check for saving an explanation many time over and loading it.

Signed-off-by: gaugup <gaugup@microsoft.com>