### PR TITLE
suppress tensorflow warnings that may sometimes occur on import

### DIFF
--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -5,7 +5,6 @@
 """Defines helpful utilities for summarizing and uploading data."""
 
 import logging
-import warnings
 
 import numpy as np
 from scipy.sparse import csr_matrix, eye, issparse
@@ -16,11 +15,10 @@ from sklearn.utils.sparsefuncs import csc_median_axis_0
 
 from .constants import Scipy
 from .gpu_kmeans import kmeans
+from .warnings_suppressor import shap_warnings_suppressor
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
-
 
 module_logger = logging.getLogger(__name__)
 module_logger.setLevel(logging.INFO)

--- a/python/interpret_community/common/warnings_suppressor.py
+++ b/python/interpret_community/common/warnings_suppressor.py
@@ -1,0 +1,66 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+"""Suppresses warnings on imports."""
+
+import os
+import warnings
+
+TF_CPP_MIN_LOG_LEVEL = 'TF_CPP_MIN_LOG_LEVEL'
+
+
+class tf_warnings_suppressor(object):
+    """Context manager to suppress warnings from tensorflow."""
+
+    def __init__(self):
+        """Initialize the tf_warnings_suppressor."""
+        self._entered = False
+        if TF_CPP_MIN_LOG_LEVEL in os.environ:
+            self._default_tf_log_level = os.environ[TF_CPP_MIN_LOG_LEVEL]
+        else:
+            self._default_tf_log_level = '0'
+
+    def __enter__(self):
+        """Begins suppressing tensorflow warnings."""
+        if self._entered:
+            raise RuntimeError("Cannot enter %r twice" % self)
+        self._entered = True
+        os.environ[TF_CPP_MIN_LOG_LEVEL] = '2'
+
+    def __exit__(self, *exc_info):
+        """Finishes suppressing tensorflow warnings."""
+        if not self._entered:
+            raise RuntimeError("Cannot exit %r without entering first" % self)
+        os.environ[TF_CPP_MIN_LOG_LEVEL] = self._default_tf_log_level
+
+
+class shap_warnings_suppressor(object):
+    """Context manager to suppress warnings from shap."""
+
+    def __init__(self):
+        """Initialize the shap_warnings_suppressor."""
+        self._catch_warnings = warnings.catch_warnings()
+        self._tf_warnings_suppressor = tf_warnings_suppressor()
+        self._entered = False
+        if TF_CPP_MIN_LOG_LEVEL in os.environ:
+            self._default_tf_log_level = os.environ[TF_CPP_MIN_LOG_LEVEL]
+        else:
+            self._default_tf_log_level = '0'
+
+    def __enter__(self):
+        """Begins suppressing shap warnings."""
+        if self._entered:
+            raise RuntimeError("Cannot enter %r twice" % self)
+        self._entered = True
+        self._tf_warnings_suppressor.__enter__()
+        log = self._catch_warnings.__enter__()
+        warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+        return log
+
+    def __exit__(self, *exc_info):
+        """Finishes suppressing shap warnings."""
+        if not self._entered:
+            raise RuntimeError("Cannot exit %r without entering first" % self)
+        self._tf_warnings_suppressor.__exit__()
+        self._catch_warnings.__exit__()

--- a/python/interpret_community/mimic/models/lightgbm_model.py
+++ b/python/interpret_community/mimic/models/lightgbm_model.py
@@ -15,21 +15,24 @@ from scipy.sparse import issparse
 from ...common.constants import (ExplainableModelType, Extension,
                                  LightGBMSerializationConstants,
                                  ShapValuesOutput)
+from ...common.warnings_suppressor import shap_warnings_suppressor
 from .explainable_model import (BaseExplainableModel, _clean_doc,
                                 _get_initializer_args)
 from .tree_model_utils import (_expected_values_tree_surrogate,
                                _explain_local_tree_surrogate)
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
-    try:
-        import lightgbm
-        from lightgbm import Booster, LGBMClassifier, LGBMRegressor
-        if (version.parse(lightgbm.__version__) <= version.parse('2.2.1')):
-            print("Using older than supported version of lightgbm, please upgrade to version greater than 2.2.1")
-    except ImportError:
-        print("Could not import lightgbm, required if using LGBMExplainableModel")
+
+
+try:
+    import lightgbm
+    from lightgbm import Booster, LGBMClassifier, LGBMRegressor
+    if (version.parse(lightgbm.__version__) <= version.parse('2.2.1')):
+        print("Using older than supported version of lightgbm, please upgrade to version greater than 2.2.1")
+except ImportError:
+    print("Could not import lightgbm, required if using LGBMExplainableModel")
+
 
 DEFAULT_RANDOM_STATE = 123
 _N_FEATURES = '_n_features'

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -3,7 +3,6 @@
 # ---------------------------------------------------------
 
 """Defines an explainable linear model."""
-import warnings
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse
@@ -12,11 +11,11 @@ from sklearn.linear_model import (Lasso, LinearRegression, LogisticRegression,
 
 from ...common.constants import ExplainableModelType, Extension, SHAPDefaults
 from ...common.explanation_utils import _summarize_data
+from ...common.warnings_suppressor import shap_warnings_suppressor
 from .explainable_model import (BaseExplainableModel, _clean_doc,
                                 _get_initializer_args)
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 DEFAULT_RANDOM_STATE = 123

--- a/python/interpret_community/mimic/models/tree_model.py
+++ b/python/interpret_community/mimic/models/tree_model.py
@@ -4,20 +4,18 @@
 
 """Defines an explainable tree model."""
 
-import warnings
-
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 from ...common.constants import (ExplainableModelType, Extension,
                                  ShapValuesOutput)
 from ...common.explanation_utils import _get_dense_examples
+from ...common.warnings_suppressor import shap_warnings_suppressor
 from .explainable_model import (BaseExplainableModel, _clean_doc,
                                 _get_initializer_args)
 from .tree_model_utils import (_expected_values_tree_surrogate,
                                _explain_local_tree_surrogate)
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 DEFAULT_RANDOM_STATE = 123

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -6,7 +6,6 @@
 
 import logging
 import sys
-import warnings
 
 import numpy as np
 from interpret_community._internal.raw_explain.raw_explain_utils import (
@@ -20,14 +19,15 @@ from ..common.aggregate import (add_explain_global_method,
                                 init_aggregator_decorator)
 from ..common.explanation_utils import _convert_to_list, _get_dense_examples
 from ..common.structured_model_explainer import StructuredInitModelExplainer
+from ..common.warnings_suppressor import (shap_warnings_suppressor,
+                                          tf_warnings_suppressor)
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,
     _get_raw_explainer_create_explanation_kwargs)
 from .kwargs_utils import _get_explain_global_kwargs
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -4,8 +4,6 @@
 
 """Defines the KernelExplainer for computing explanations on black box models or functions."""
 
-import warnings
-
 import numpy as np
 
 from .._internal.raw_explain.raw_explain_utils import (
@@ -20,6 +18,7 @@ from ..common.explanation_utils import (_append_shap_values_instance,
                                         _convert_single_instance_to_multi,
                                         _convert_to_list)
 from ..common.model_wrapper import _wrap_model
+from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
@@ -27,8 +26,7 @@ from ..explanation.explanation import (
     _get_raw_explainer_create_explanation_kwargs)
 from .kwargs_utils import _get_explain_global_kwargs
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -4,8 +4,6 @@
 
 """Defines the LinearExplainer for returning explanations for linear models."""
 
-import warnings
-
 import numpy as np
 
 from .._internal.raw_explain.raw_explain_utils import (
@@ -16,6 +14,7 @@ from ..common.constants import (Attributes, Defaults, ExplainParams,
                                 ExplainType, Extension, SHAPDefaults, SKLearn)
 from ..common.explanation_utils import _fix_linear_explainer_shap_values
 from ..common.structured_model_explainer import StructuredInitModelExplainer
+from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import tabular_decorator
 from ..explanation.explanation import (
@@ -23,8 +22,7 @@ from ..explanation.explanation import (
     _get_raw_explainer_create_explanation_kwargs)
 from .kwargs_utils import _get_explain_global_kwargs
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -4,8 +4,6 @@
 
 """Defines the TreeExplainer for returning explanations for tree-based models."""
 
-import warnings
-
 import numpy as np
 
 from .._internal.raw_explain.raw_explain_utils import (
@@ -17,6 +15,7 @@ from ..common.constants import (Defaults, ExplainParams, ExplainType,
 from ..common.explanation_utils import (_convert_to_list, _get_dense_examples,
                                         _scale_tree_shap)
 from ..common.structured_model_explainer import PureStructuredModelExplainer
+from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import tabular_decorator
 from ..explanation.explanation import (
@@ -24,8 +23,7 @@ from ..explanation.explanation import (
     _get_raw_explainer_create_explanation_kwargs)
 from .kwargs_utils import _get_explain_global_kwargs
 
-with warnings.catch_warnings():
-    warnings.filterwarnings('ignore', 'Starting from version 2.2.1', UserWarning)
+with shap_warnings_suppressor():
     import shap
 
 


### PR DESCRIPTION
Customer was seeing warnings printed:
```
2022-01-03 19:51:39.840150: W tensorflow/stream_executor/platform/default/dso_loader.cc:59] Could not load dynamic library 'libcudart.so.10.1'; dlerror: libcudart.so.10.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/intel64/lib:/opt/intel/compilers_and_libraries_2018.3.222/linux/mpi/mic/lib::/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64/
2022-01-03 19:51:39.840205: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
```
We never actually import tensorflow directly, but shap does.  This PR suppresses the tensorflow warning on shap import.