### PR TITLE
fix flake8 error on builds

### DIFF
--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -70,6 +70,18 @@ steps:
     pip install -r requirements-vis.txt
   displayName: Install vis required pip packages
 
+- bash: |
+      source activate ${{parameters.condaEnv}}
+      flake8 --max-line-length=119 --exclude=.git/,__pycache__/,dist/ .
+  failOnStderr: true
+  displayName: 'Run flake8'
+
+- bash: |
+      source activate ${{parameters.condaEnv}}
+      isort . -c
+  failOnStderr: true
+  displayName: 'Make sure imports are sorted'
+
 - ${{ if eq(parameters.testRunType, 'Unit')}}:
   - bash: |
         source activate ${{parameters.condaEnv}}
@@ -103,10 +115,3 @@ steps:
     failTaskOnFailedTests: true
   condition: succeededOrFailed()
   displayName: 'Publish Test Results'
-
-- bash: |
-      source activate ${{parameters.condaEnv}}
-      python -m pip install flake8, flake8-bugbear==21.11.29, flake8-blind-except==0.1.1, flake8-breakpoint, flake8-logging-format==0.6.0, isort
-      flake8 --max-line-length=119 --exclude=.git/,__pycache__/,dist/ .
-      isort . -c
-  displayName: 'Run flake8 and make sure imports are sorted'

--- a/python/interpret_community/mimic/models/lightgbm_model.py
+++ b/python/interpret_community/mimic/models/lightgbm_model.py
@@ -7,7 +7,6 @@
 import inspect
 import json
 import logging
-import warnings
 
 from packaging import version
 from scipy.sparse import issparse

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -19,8 +19,7 @@ from ..common.aggregate import (add_explain_global_method,
                                 init_aggregator_decorator)
 from ..common.explanation_utils import _convert_to_list, _get_dense_examples
 from ..common.structured_model_explainer import StructuredInitModelExplainer
-from ..common.warnings_suppressor import (shap_warnings_suppressor,
-                                          tf_warnings_suppressor)
+from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,


### PR DESCRIPTION
Seeing flake8 errors on builds, even though the builds succeed:
![image](https://user-images.githubusercontent.com/24683184/148440767-a8eee648-92a4-41ec-bcd6-4d23b0c7409a.png)

This PR tries to fix it by moving the flake8 check before the publish tests step, and it also removes the code to install flake8 et al because these should already be installed from the test dependencies file (https://github.com/interpretml/interpret-community/blob/master/requirements-test.txt).

The PR sets "failOnStderr: true" to fail the linting task run on bash if there is stderr.
Also, it splits the linting and isort into two tasks, otherwise the build succeeds even if linting fails currently, since bash task only checks the output of the last run statement.