### PR TITLE
fix reimports from ml-wrappers package for WrappedClassificationModel, WrappedRegressionModel

### DIFF
--- a/python/interpret_community/common/model_wrapper/__init__.py
+++ b/python/interpret_community/common/model_wrapper/__init__.py
@@ -4,6 +4,8 @@
 
 """Reimports helpful model wrapper and utils for implicitly rewrapping the model to conform to explainer contracts."""
 
-from ml_wrappers.model import WrappedPytorchModel, _wrap_model, wrap_model
+from ml_wrappers.model import (WrappedClassificationModel, WrappedPytorchModel,
+                               WrappedRegressionModel, _wrap_model, wrap_model)
 
-__all__ = ['WrappedPytorchModel', '_wrap_model', 'wrap_model']
+__all__ = ['WrappedClassificationModel', 'WrappedPytorchModel',
+           'WrappedRegressionModel', '_wrap_model', 'wrap_model']

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,7 +39,7 @@ DEPENDENCIES = [
     'numpy',
     'pandas',
     'scipy',
-    'ml-wrappers==0.0.5',
+    'ml-wrappers==0.0.6',
     'scikit-learn',
     'packaging',
     'interpret-core[required]>=0.1.20, <=0.2.7',


### PR DESCRIPTION
a downstream package has issues because it reimported these from interpret-community, which did not reimport them from ml-wrappers