### PR TITLE
replace numpy.array with numpy.ndarray in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ jupyter notebook
 # <a name="models"></a>
 # Supported Models
 
-This API supports models that are trained on datasets in Python `numpy.array`, `pandas.DataFrame`, or `scipy.sparse.csr_matrix` format.
+This API supports models that are trained on datasets in Python `numpy.ndarray`, `pandas.DataFrame`, or `scipy.sparse.csr_matrix` format.
 
 
 The explanation functions accept both models and pipelines as input as long as the model or pipeline implements a `predict` or `predict_proba` function that conforms to the Scikit convention. If not compatible, you can wrap your model's prediction function into a wrapper function that transforms the output into the format that is supported (predict or predict_proba of Scikit), and pass that wrapper function to your selected interpretability techniques.  

--- a/python/interpret_community/_internal/raw_explain/data_mapper.py
+++ b/python/interpret_community/_internal/raw_explain/data_mapper.py
@@ -38,7 +38,7 @@ class TransformationsListTransformer:
         """Transform data when the user provides a list of transformations in sklearn-pandas format.
 
         :param x: input data
-        :type x: numpy.array or scipy.sparse matrix
+        :type x: numpy.ndarray or scipy.sparse matrix
         :return: transformed data
         """
         results = []
@@ -65,7 +65,7 @@ class DataMapper(object):
         :param transformations: List of (column_name, transformer) tuples or sklearn.compose.ColumnTransformer
         :type transformations: list[tuple(str, (class containing .transform method))]
         :param examples: DataFrame or numpy array of input
-        :type examples: pandas.DataFrame or numpy.array
+        :type examples: pandas.DataFrame or numpy.ndarray
         :param allow_all_transformations: Allow many to many and many to one transformations
         :type allow_all_transformations: bool
         """
@@ -80,7 +80,7 @@ class DataMapper(object):
         """Feature map from raw to generated.
 
         :return: mapping from raw to generated features
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         if self._feature_map is None:
             raise ValueError("Feature map not built. Run transform first.")
@@ -202,8 +202,8 @@ class DataMapper(object):
         """Run the transform methods associated with each feature_mapper. This will set the featmaps.
 
         :param x: input data
-        :type x: numpy.array or DataFrame
-        :return: numpy.array or scipy.sparse.csr_matrix
+        :type x: numpy.ndarray or DataFrame
+        :return: numpy.ndarray or scipy.sparse.csr_matrix
         """
         for transformer_config, feature_mapper in self._feature_mappers_pipeline:
             feature_mapper.transform(extract_column(x, transformer_config))
@@ -212,9 +212,9 @@ class DataMapper(object):
         """Transform input data given the transformations.
 
         :param x: input data
-        :type x: pandas.DataFrame or numpy.array
+        :type x: pandas.DataFrame or numpy.ndarray
         :return: transformed data
-        :rtype: numpy.array or scipy.sparse.csr_matrix
+        :rtype: numpy.ndarray or scipy.sparse.csr_matrix
         """
         if self._feature_map is None:
             # pass a single example through the transformations list to build feature map

--- a/python/interpret_community/_internal/raw_explain/data_mapper_utils.py
+++ b/python/interpret_community/_internal/raw_explain/data_mapper_utils.py
@@ -25,11 +25,11 @@ def extract_column(x, transformer_config):
     """Extract column from DataFrame/numpy array x and reshape if column_name is list.
 
     :param x: input raw data
-    :type x: numpy.array or pandas.DataFrame
+    :type x: numpy.ndarray or pandas.DataFrame
     :param transformer_config: TransformerConfig used to reshape input data
     :type transformer_config: TransformerConfig
     :return: column or columns from input data
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     columns = transformer_config.columns
 

--- a/python/interpret_community/_internal/raw_explain/feature_mappers.py
+++ b/python/interpret_community/_internal/raw_explain/feature_mappers.py
@@ -62,9 +62,9 @@ class FeatureMapper(ABC):
         """
 
         :param x: input data
-        :type x: pandas.DataFrame or numpy.array
+        :type x: pandas.DataFrame or numpy.ndarray
         :rtype: transformed data
-        :rtype: numpy.array or scipy.sparse matrix
+        :rtype: numpy.ndarray or scipy.sparse matrix
         """
         pass
 
@@ -73,7 +73,7 @@ class FeatureMapper(ABC):
         """
 
         :return: feature map from raw to generated
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         if self._feature_map is None:
             raise ValueError("transform not called")
@@ -83,7 +83,7 @@ class FeatureMapper(ABC):
         """
 
         :param feature_map: feature map associated with the FeatureMapper
-        :type feature_map: numpy.array
+        :type feature_map: numpy.ndarray
         """
         self._feature_map = feature_map
 
@@ -91,7 +91,7 @@ class FeatureMapper(ABC):
         """Dummy fit so that this can go in an sklearn.pipeline.Pipeline.
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: self
         :rtype: FeatureMapper
         """
@@ -121,9 +121,9 @@ class IdentityMapper(FeatureMapper):
         """Transform input data.
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: transformed data
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         result = self.transformer.transform(x)
         if self._feature_map is None:
@@ -155,9 +155,9 @@ class PassThroughMapper(FeatureMapper):
         """
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: transformed data
-        :rytpe: numpy.array or scipy.sparse matrix
+        :rytpe: numpy.ndarray or scipy.sparse matrix
         """
         x_transformed = self.transformer.transform(x)
         if self._feature_map is None:
@@ -194,9 +194,9 @@ class PipelineFeatureMapper(FeatureMapper):
         """
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: transformed data
-        :rtype: numpy.array or scipy.sparse matrix
+        :rtype: numpy.ndarray or scipy.sparse matrix
         """
         ret = self.transformer.transform(x)
         if self._feature_map is None:
@@ -249,9 +249,9 @@ class OneHotEncoderMapper(FeatureMapper):
         """
 
         :param x: input data
-        :type x: numpy.array
+        :type x: numpy.ndarray
         :return: transformed data
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         ret = self.transformer.transform(x)
         if self._feature_map is None:
@@ -285,9 +285,9 @@ class ManytoManyMapper(FeatureMapper):
         """Get transformed data from input.
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: transformed data
-        :rtype: numpy.array or scipy.sparse matrix
+        :rtype: numpy.ndarray or scipy.sparse matrix
         """
         x_transformed = self._transformer.transform(x)
         if self._feature_map is None:
@@ -301,7 +301,7 @@ class FuncTransformer:
         """
 
         :param func: function that transforms the data
-        :type func: function that takes in numpy.array/pandas.Dataframe and outputs numpy.array or scipy.sparse matrix
+        :type func: function that takes in numpy.ndarray/pandas.Dataframe and outputs numpy.ndarray/scipy.sparse matrix
         """
         self._func = func
 
@@ -309,9 +309,9 @@ class FuncTransformer:
         """
 
         :param x: input data
-        :type x: numpy.array or pandas.DataFrame
+        :type x: numpy.ndarray or pandas.DataFrame
         :return: transformed data
-        :rtype: numpy.array or scipy.sparse matrix
+        :rtype: numpy.ndarray or scipy.sparse matrix
         """
         return self._func(x)
 

--- a/python/interpret_community/_internal/raw_explain/raw_explain_utils.py
+++ b/python/interpret_community/_internal/raw_explain/raw_explain_utils.py
@@ -13,11 +13,11 @@ def transform_with_datamapper(x, datamapper):
     """Transform the input using the _datamapper field in obj.
 
     :param x: input data
-    :type x: numpy.array or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
+    :type x: numpy.ndarray or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
     :param datamapper: datamapper object
     :type datamapper: DataMapper
     :return: transformed data
-    :rtype: numpy.array or scipy.sparse matrix or DatasetWrapper
+    :rtype: numpy.ndarray or scipy.sparse matrix or DatasetWrapper
     """
     x_is_dataset_wrapper = isinstance(x, DatasetWrapper)
     input_data = x
@@ -35,7 +35,7 @@ def get_datamapper_and_transformed_data(examples=None, transformations=None, all
     """Get data mapper as well as transformed examples.
 
     :param examples: input data
-    :type examples: numpy.array or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
+    :type examples: numpy.ndarray or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
     :param transformations: transformations passed from any of DeepExplainer, KernelExplainer, MimicExplainer,
     TreeExplainer and TabularExplainer
     :type transformations: documented in constructor params of any of DeepExplainer, KernelExplainer, MimicExplainer,

--- a/python/interpret_community/adapter/explanation_adapter.py
+++ b/python/interpret_community/adapter/explanation_adapter.py
@@ -42,12 +42,12 @@ class ExplanationAdapter(object):
         """Create a local explanation from the list of local feature importance values.
 
         :param local_importance_values: The feature importance values.
-        :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+        :type local_importance_values: numpy.ndarray or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param expected_values: The expected values of the model.
-        :type expected_values: numpy.array
+        :type expected_values: numpy.ndarray
         """
         local_importance_values = np.array(local_importance_values)
         # handle the case that the local importance values have a 2d shape for classification scenario
@@ -73,12 +73,12 @@ class ExplanationAdapter(object):
         """Create a global explanation from the list of local feature importance values.
 
         :param local_importance_values: The feature importance values.
-        :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+        :type local_importance_values: numpy.ndarray or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param expected_values: The expected values of the model.
-        :type expected_values: numpy.array
+        :type expected_values: numpy.ndarray
         :param include_local: Include the local explanations in the returned global explanation.
             If include_local is False, will stream the local explanations to aggregate to global.
         :type include_local: bool

--- a/python/interpret_community/common/aggregate.py
+++ b/python/interpret_community/common/aggregate.py
@@ -38,7 +38,7 @@ def add_explain_global_method(cls):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -59,7 +59,7 @@ def add_explain_global_method(cls):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy

--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -23,7 +23,7 @@ class _Wrapper(object):
 
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param function: The function to explain.
     :type function: function that accepts a 2d ndarray
     """
@@ -33,7 +33,7 @@ class _Wrapper(object):
 
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param function: The function to explain.
         :type function: function that accepts a 2d ndarray
         """
@@ -44,7 +44,7 @@ class _Wrapper(object):
         """Combine the prediction function and type cast function into a single function.
 
         :param dataset: A matrix of feature vector examples (# examples x # features).
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         """
         return self.function(self.typed_wrapper_func(dataset))
 
@@ -106,7 +106,7 @@ class BlackBoxMixin(ChainedIdentity):
         """Get the predicted ys to be incorporated into a kwargs dictionary.
         :param evaluation_examples: The same ones we usually work with, must be able to be passed into the
             model or function.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param transformations: See documentation on any explainer.
         :type transformations: sklearn.compose.ColumnTransformer or list[tuple]
         :param allow_all_transformations: Allow many to many and many to one transformations

--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -37,7 +37,7 @@ def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
     median for dense columns.
 
     :param X: Matrix of data samples to summarize (# samples x # features).
-    :type X: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type X: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param k: Number of cluster centroids to use for approximation.
     :type k: int
     :param to_round_values: When using kmeans, for each element of every cluster centroid to match the nearest value
@@ -45,7 +45,7 @@ def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
         always get a valid value.  Ignored for sparse data sample.
     :type to_round_values: bool
     :return: summarized numpy array or csr_matrix object.
-    :rtype: numpy.array or scipy.sparse.csr_matrix or DenseData
+    :rtype: numpy.ndarray or scipy.sparse.csr_matrix or DenseData
     """
     is_sparse = issparse(X)
     if not str(type(X)).endswith(".DenseData'>"):
@@ -91,11 +91,11 @@ def _get_raw_feature_importances(importance_values, raw_to_output_feature_maps):
     """Return raw feature importance values.
 
     :param importance_values: The importance values computed for the dataset.
-    :type importance_values: numpy.array or list[scipy.sparse.csr_matrix]
+    :type importance_values: numpy.ndarray or list[scipy.sparse.csr_matrix]
     :param raw_to_output_feature_maps: A list of feature maps from raw to generated feature.
-    :type raw_to_output_feature_maps: list[Union[numpy.array, scipy.sparse.csr_matrix]]
+    :type raw_to_output_feature_maps: list[Union[numpy.ndarray, scipy.sparse.csr_matrix]]
     :return: Raw feature importance values.
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     if not isinstance(raw_to_output_feature_maps, list):
         raise ValueError("raw_to_output_feature_maps should be a list of feature maps")
@@ -167,11 +167,11 @@ def _multiply_sparse_matrix_3d_numpy_tensor(np_tensor, sp_matrix):
     """Multiply sparse matrix with a 3 dimension numpy array.
 
     :param np_tensor: numpy tensor of 3 dimensions.
-    :type np_tensor: numpy.array
+    :type np_tensor: numpy.ndarray
     :param sp_matrix: sparse matrix
     :type sp_matrix: scipy.sparse.csr_matrix
     :return: The product of numpy array and sparse matrix.
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     if len(np_tensor.shape) != 3:
         raise ValueError("Expected matrix of dimension 3. Got dimension {}.".format(len(np_tensor.shape)))
@@ -212,11 +212,11 @@ def _generate_augmented_data(x, max_num_of_augmentations=np.inf):
     """Augment x by appending x with itself shuffled columnwise many times.
 
     :param x: data that has to be augmented, array or sparse matrix of 2 dimensions
-    :type x: numpy.array or scipy.sparse.csr_matrix
+    :type x: numpy.ndarray or scipy.sparse.csr_matrix
     :param max_augment_data_size: number of times we stack permuted x to augment.
     :type max_augment_data_size: int
     :return: augmented data with roughly number of rows that are equal to number of columns
-    :rtype: numpy.array or scipy.sparse.csr_matrix
+    :rtype: numpy.ndarray or scipy.sparse.csr_matrix
     """
     x_augmented = x
     vstack = sparse_vstack if issparse(x) else np.vstack
@@ -236,13 +236,13 @@ def _scale_tree_shap(shap_values, expected_values, prediction):
     https://github.com/slundberg/shap/issues/29#issuecomment-408385378
 
     :param shap_values: The shap values to transform from log odds to probabilities.
-    :type shap_values: numpy.array
+    :type shap_values: numpy.ndarray
     :param expected_values: The expected values as probabilities.
-    :type expected_values: numpy.array
+    :type expected_values: numpy.ndarray
     :param prediction: The predicted probability from the teacher model.
-    :type prediction: numpy.array
+    :type prediction: numpy.ndarray
     :return: The transformed tree shap values as probabilities.
-    :rtype: list or numpy.array
+    :rtype: list or numpy.ndarray
     """
     # In multiclass case, use expected values and predictions per class
     if isinstance(shap_values, list):
@@ -263,13 +263,13 @@ def _scale_single_shap_matrix(shap_values, expectation, prediction):
     """Scale a single class matrix of shap values to sum to the teacher model prediction.
 
     :param shap_values: The shap values of the mimic model.
-    :type shap_values: numpy.array
+    :type shap_values: numpy.ndarray
     :param expected_values: The expected values as probabilities (base values).
-    :type expected_values: numpy.array
+    :type expected_values: numpy.ndarray
     :param prediction: The predicted probability from the teacher model.
-    :type prediction: numpy.array
+    :type prediction: numpy.ndarray
     :return: The transformed tree shap values as probabilities.
-    :rtype: list or numpy.array
+    :rtype: list or numpy.ndarray
     """
     mimic_prediction = np.sum(shap_values, axis=1)
     error = prediction - mimic_prediction - expectation
@@ -296,9 +296,9 @@ def _convert_single_instance_to_multi(instance_shap_values):
     """Convert a single shap values instance to multi-instance form.
 
     :param instance_shap_values: The shap values calculated for a new instance.
-    :type instance_shap_values: numpy.array or list
+    :type instance_shap_values: numpy.ndarray or list
     :return: The instance converted to multi-instance form.
-    :rtype: numpy.array or list
+    :rtype: numpy.ndarray or list
     """
     classification = isinstance(instance_shap_values, list)
     if classification:
@@ -314,11 +314,11 @@ def _append_shap_values_instance(shap_values, instance_shap_values):
     """Append a single instance of shap values to an existing multi-instance shap values list or array.
 
     :param shap_values: The existing shap values array or list.
-    :type shap_values: numpy.array or list
+    :type shap_values: numpy.ndarray or list
     :param instance_shap_values: The shap values calculated for a new instance.
-    :type instance_shap_values: numpy.array or list
+    :type instance_shap_values: numpy.ndarray or list
     :return: The instance appended to the existing shap values.
-    :rtype: numpy.array or list
+    :rtype: numpy.ndarray or list
     """
     classification = isinstance(instance_shap_values, list)
     if classification:
@@ -343,9 +343,9 @@ def _fix_linear_explainer_shap_values(model, shap_values):
     :param model: The linear model.
     :type model: tuple of (coefficients, intercept) or sklearn.linear.* model
     :param shap_values: The existing shap values array or list.
-    :type shap_values: numpy.array or list
+    :type shap_values: numpy.ndarray or list
     :return: The shap values reshaped into the correct form for given linear model.
-    :rtype: numpy.array or list
+    :rtype: numpy.ndarray or list
     """
     # Temporary fix for a bug in shap for regression models
     if (type(model) == tuple and len(model) == 2):
@@ -371,11 +371,11 @@ def _unsort_1d(values, order):
     """Unsort a sorted 1d array based on the order that was used to sort it.
 
     :param values: The array that has been sorted.
-    :type values: numpy.array
+    :type values: numpy.ndarray
     :param order: The order list that was originally used to sort values.
-    :type order: numpy.array
+    :type order: numpy.ndarray
     :return: The unsorted array.
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     order_inverse = [None] * len(order)
     for i in range(len(order)):
@@ -503,7 +503,7 @@ def _get_feature_map_from_list_of_indexes(indices_list):
     :param indices_list: A list of lists of generated feature indices for each raw feature.
     :type indices_list: list[list[int]]
     :return: A feature map from raw to generated.
-    :rtype: numpy.array
+    :rtype: numpy.ndarray
     """
     # sets for each list of generated features
     raw_to_gen = []

--- a/python/interpret_community/common/gpu_kmeans.py
+++ b/python/interpret_community/common/gpu_kmeans.py
@@ -36,7 +36,7 @@ def kmeans(X, k, round_values=True):
     each represent.
     Parameters
     ----------
-    X : numpy.array or pandas.DataFrame or any scipy.sparse matrix
+    X : numpy.ndarray or pandas.DataFrame or any scipy.sparse matrix
         Matrix of data samples to summarize (# samples x # features)
     k : int
         Number of means to use for approximation.

--- a/python/interpret_community/common/structured_model_explainer.py
+++ b/python/interpret_community/common/structured_model_explainer.py
@@ -16,7 +16,7 @@ class StructuredInitModelExplainer(BaseExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     """
 
     def __init__(self, model, initialization_examples, **kwargs):
@@ -26,7 +26,7 @@ class StructuredInitModelExplainer(BaseExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         """
         super(StructuredInitModelExplainer, self).__init__(**kwargs)
         self._logger.debug('Initializing StructuredInitModelExplainer')

--- a/python/interpret_community/explanation/explanation.py
+++ b/python/interpret_community/explanation/explanation.py
@@ -315,14 +315,14 @@ class LocalExplanation(FeatureImportanceExplanation):
     """The common local explanation returned by explainers.
 
     :param local_importance_values: The feature importance values.
-    :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+    :type local_importance_values: numpy.ndarray or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
     """
 
     def __init__(self, local_importance_values=None, **kwargs):
         """Create the local explanation from the explainer's feature importance values.
 
         :param local_importance_values: The feature importance values.
-        :type local_importance_values: numpy.array or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+        :type local_importance_values: numpy.ndarray or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
         """
         super(LocalExplanation, self).__init__(**kwargs)
         self._logger.debug('Initializing LocalExplanation')
@@ -466,11 +466,11 @@ class LocalExplanation(FeatureImportanceExplanation):
             the raw to generated maps in the same order as t1, t2, etc. If the overall raw to
             generated feature map from t1 to tn is available, then just that feature map
             in a single element list can be passed.
-        :type feature_maps: list[Union[numpy.array, scipy.sparse.csr_matrix]]
+        :type feature_maps: list[Union[numpy.ndarray, scipy.sparse.csr_matrix]]
         :param raw_feature_names: list of raw feature names
         :type raw_feature_names: [str]
         :param eval_data: Evaluation data.
-        :type eval_data: numpy.array or pandas.DataFrame
+        :type eval_data: numpy.ndarray or pandas.DataFrame
         :return: raw explanation
         :rtype: LocalExplanation
         """
@@ -491,7 +491,7 @@ class LocalExplanation(FeatureImportanceExplanation):
         local_importance_values.
 
         :param raw_to_output_maps: A list of feature maps from raw to generated feature.
-        :type raw_to_output_maps: list[numpy.array]
+        :type raw_to_output_maps: list[numpy.ndarray]
         :return: Raw feature importance.
         :rtype: list[list] or list[list[list]]
         """
@@ -641,13 +641,13 @@ class GlobalExplanation(FeatureImportanceExplanation):
     """The common global explanation returned by explainers.
 
     :param global_importance_values: The feature importance values in the order of the original features.
-    :type global_importance_values: numpy.array
+    :type global_importance_values: numpy.ndarray
     :param global_importance_rank: The feature indexes sorted by importance.
-    :type global_importance_rank: numpy.array
+    :type global_importance_rank: numpy.ndarray
     :param ranked_global_names: The feature names sorted by importance.
     :type ranked_global_names: list[str] TODO
     :param ranked_global_values: The feature importance values sorted by importance.
-    :type ranked_global_values: numpy.array
+    :type ranked_global_values: numpy.ndarray
     """
 
     def __init__(self,
@@ -659,13 +659,13 @@ class GlobalExplanation(FeatureImportanceExplanation):
         """Create the global explanation from the explainer's overall importance values and order.
 
         :param global_importance_values: The feature importance values in the order of the original features.
-        :type global_importance_values: numpy.array
+        :type global_importance_values: numpy.ndarray
         :param global_importance_rank: The feature indexes sorted by importance.
-        :type global_importance_rank: numpy.array
+        :type global_importance_rank: numpy.ndarray
         :param ranked_global_names: The feature names sorted by importance.
         :type ranked_global_names: list[str] TODO
         :param ranked_global_values: The feature importance values sorted by importance.
-        :type ranked_global_values: numpy.array
+        :type ranked_global_values: numpy.ndarray
         """
         super(GlobalExplanation, self).__init__(**kwargs)
         self._logger.debug('Initializing GlobalExplanation')
@@ -754,11 +754,11 @@ class GlobalExplanation(FeatureImportanceExplanation):
             the raw to generated maps in the same order as t1, t2, etc. If the overall raw to
             generated feature map from t1 to tn is available, then just that feature map
             in a single element list can be passed.
-        :type feature_maps: list[Union[numpy.array, scipy.sparse.csr_matrix]]
+        :type feature_maps: list[Union[numpy.ndarray, scipy.sparse.csr_matrix]]
         :param raw_feature_names: list of raw feature names
         :type raw_feature_names: [str]
         :param eval_data: Evaluation data.
-        :type eval_data: numpy.array or pandas.DataFrame
+        :type eval_data: numpy.ndarray or pandas.DataFrame
         :return: raw explanation
         :rtype: GlobalExplanation
         """
@@ -886,14 +886,14 @@ class ExpectedValuesMixin(object):
     """The explanation mixin for expected values.
 
     :param expected_values: The expected values of the model.
-    :type expected_values: numpy.array
+    :type expected_values: numpy.ndarray
     """
 
     def __init__(self, expected_values=None, **kwargs):
         """Create the expected values mixin and set the expected values.
 
         :param expected_values: The expected values of the model.
-        :type expected_values: numpy.array
+        :type expected_values: numpy.ndarray
         """
         super(ExpectedValuesMixin, self).__init__(**kwargs)
         self._expected_values = expected_values
@@ -1058,13 +1058,13 @@ class PerClassMixin(ClassesMixin):
     local importance values across different classes.
 
     :param per_class_values: The feature importance values for each class in the order of the original features.
-    :type per_class_values: numpy.array
+    :type per_class_values: numpy.ndarray
     :param per_class_importance_rank: The feature indexes for each class sorted by importance.
-    :type per_class_importance_rank: numpy.array
+    :type per_class_importance_rank: numpy.ndarray
     :param ranked_per_class_names: The feature names for each class sorted by importance.
     :type ranked_per_class_names: list[str]
     :param ranked_per_class_values: The feature importance values sorted by importance.
-    :type ranked_per_class_values: numpy.array
+    :type ranked_per_class_values: numpy.ndarray
     """
 
     def __init__(self,
@@ -1076,13 +1076,13 @@ class PerClassMixin(ClassesMixin):
         """Create the per class mixin from the explainer's importance values and order.
 
         :param per_class_values: The feature importance values for each class in the order of the original features.
-        :type per_class_values: numpy.array
+        :type per_class_values: numpy.ndarray
         :param per_class_importance_rank: The feature indexes for each class sorted by importance.
-        :type per_class_importance_rank: numpy.array
+        :type per_class_importance_rank: numpy.ndarray
         :param ranked_per_class_names: The feature names for each class sorted by importance.
         :type ranked_per_class_names: list[str]
         :param ranked_per_class_values: The feature importance values sorted by importance.
-        :type ranked_per_class_values: numpy.array
+        :type ranked_per_class_values: numpy.ndarray
         """
         super(PerClassMixin, self).__init__(**kwargs)
         self._per_class_values = per_class_values
@@ -1194,15 +1194,15 @@ class _DatasetsMixin(object):
     If this explanation has been downloaded from run history, these will always be ID strings.
 
     :param init_data: The initialization (background) data used in the explanation, or a Dataset ID.
-    :type init_data: numpy.array or str
+    :type init_data: numpy.ndarray or str
     :param eval_data: The evaluation (testing) data used in the explanation, or a Dataset ID.
-    :type eval_data: numpy.array or str
+    :type eval_data: numpy.ndarray or str
     :param eval_y_predicted: The predicted ys for the evaluation data or Dataset ID.
         Not available from the DeepExplainer.
-    :type eval_y_predicted: numpy.array or str
+    :type eval_y_predicted: numpy.ndarray or str
     :param eval_y_predicted_proba: The predicted probability ys for the evaluation data or Dataset ID.
         Not available from the DeepExplainer.
-    :type eval_y_predicted_proba: numpy.array or str
+    :type eval_y_predicted_proba: numpy.ndarray or str
     """
 
     def __init__(self,
@@ -1216,15 +1216,15 @@ class _DatasetsMixin(object):
         If this explanation has been downloaded from run history, these will always be ID strings.
 
         :param init_data: The initialization (background) data used in the explanation, or a Dataset ID.
-        :type init_data: numpy.array or str
+        :type init_data: numpy.ndarray or str
         :param eval_data: The evaluation (testing) data used in the explanation, or a Dataset ID.
-        :type eval_data: numpy.array or str
+        :type eval_data: numpy.ndarray or str
         :param eval_y_predicted: The predicted ys for the evaluation data or Dataset ID.
             Not available from the DeepExplainer.
-        :type eval_y_predicted: numpy.array or str
+        :type eval_y_predicted: numpy.ndarray or str
         :param eval_y_predicted_proba: The predicted probability ys for the evaluation data or Dataset ID.
             Not available from the DeepExplainer.
-        :type eval_y_predicted_proba: numpy.array or str
+        :type eval_y_predicted_proba: numpy.ndarray or str
         """
         super(_DatasetsMixin, self).__init__(**kwargs)
         self._init_data = init_data
@@ -1272,7 +1272,7 @@ class _DatasetsMixin(object):
         """Convert data to a Python list.
 
         :param data: The data to be converted.
-        :type data: Union[numpy.array, pandas.DataFrame, list, scipy.sparse]
+        :type data: Union[numpy.ndarray, pandas.DataFrame, list, scipy.sparse]
         :return: The data converted to a list (except for sparse or dataset ID which is unchanged).
         :rtype: list or scipy.sparse or list[scipy.sparse] or str
         """
@@ -1370,9 +1370,9 @@ def _create_local_explanation(expected_values=None, classification=True, explana
     :param eval_data: The evaluation (testing) data for the explanation.
     :type eval_data: list
     :param eval_ys_predicted: The predicted ys for the evaluation data.
-    :type eval_ys_predicted: numpy.array
+    :type eval_ys_predicted: numpy.ndarray
     :param eval_ys_predicted_proba: The predicted probability ys for the evaluation data.
-    :type eval_ys_predicted_proba: numpy.array
+    :type eval_ys_predicted_proba: numpy.ndarray
     :param model_id: The model ID.
     :type model_id: str
     :return: A model explanation object. It is guaranteed to be a LocalExplanation. If expected_values is not None, it
@@ -1430,9 +1430,9 @@ def _create_global_explanation_kwargs(local_explanation=None, expected_values=No
     :param eval_data: The evaluation (testing) data for the explanation.
     :type eval_data: list
     :param eval_ys_predicted: The predicted ys for the evaluation data.
-    :type eval_ys_predicted: numpy.array
+    :type eval_ys_predicted: numpy.ndarray
     :param eval_ys_predicted_proba: The predicted probability ys for the evaluation data.
-    :type eval_ys_predicted_proba: numpy.array
+    :type eval_ys_predicted_proba: numpy.ndarray
     :param eval_data: list
     :param model_id: The model ID.
     :type model_id: str

--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -50,7 +50,7 @@ class LIMEExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param is_function: Default set to false, set to True if passing function instead of model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -131,7 +131,7 @@ class LIMEExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param is_function: Default set to false, set to True if passing function instead of model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -258,7 +258,7 @@ class LIMEExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -55,7 +55,7 @@ class MimicExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explainable_model: The uninitialized surrogate model used to explain the black box model.
         Also known as the student model.
     :type explainable_model: interpret_community.mimic.models.BaseExplainableModel
@@ -152,7 +152,7 @@ class MimicExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explainable_model: The uninitialized surrogate model used to explain the black box model.
             Also known as the student model.
         :type explainable_model: BaseExplainableModel
@@ -321,9 +321,9 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.  If specified, computes feature importance through aggregation.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Transformed data.
-        :rtype: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :rtype: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         """
         if self.transformations is not None:
             _, transformed_evaluation_examples = get_datamapper_and_transformed_data(
@@ -339,9 +339,9 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.  If specified, computes feature importance through aggregation.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: predictions of the surrogate model.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         transformed_evaluation_examples = self._get_transformed_data(evaluation_examples)
         if self.classes is not None and len(self.classes) == 2:
@@ -358,9 +358,9 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.  If specified, computes feature importance through aggregation.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: predictions of the surrogate model.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         transformed_evaluation_examples = self._get_transformed_data(evaluation_examples)
         return self.model.predict(transformed_evaluation_examples)
@@ -377,7 +377,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.  If specified, computes feature importance through aggregation.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param include_local: Include the local explanations in the returned global explanation.
             If evaluation examples are specified and include_local is False, will stream the local
             explanations to aggregate to global.
@@ -440,7 +440,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.  If specified, computes feature importance through aggregation.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param include_local: Include the local explanations in the returned global explanation.
             If evaluation examples are specified and include_local is False, will stream the local
             explanations to aggregate to global.
@@ -504,7 +504,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param from_global: True if this is called from the explain_global API.
         :type from_global: bool
         :return: Args for explain_local.
@@ -591,7 +591,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param from_global: True if this is called from the explain_global API.
         :type from_global: bool
         :return: kwargs for building the model explanation object
@@ -621,7 +621,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param from_global: True if this is called from the explain_global API.
         :type from_global: bool
         :return: A model explanation object. It is guaranteed to be a LocalExplanation. If the model is a classifier,
@@ -643,7 +643,7 @@ class MimicExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: A model explanation object. It is guaranteed to be a LocalExplanation. If the model is a classifier,
             it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation
@@ -756,7 +756,7 @@ class MimicExplainer(BlackBoxExplainer):
         this function will return r2_score.
 
         :param training_data: The data for getting the replication metric.
-        :type training_data: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type training_data: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Metric that tells how well the surrogate model replicates the behavior of teacher model.
         :rtype: float
         """
@@ -781,7 +781,7 @@ class MimicExplainer(BlackBoxExplainer):
         this function will return r2_score.
 
         :param training_data: The data for getting the replication metric.
-        :type training_data: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type training_data: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Metric that tells how well the surrogate model replicates the behavior of teacher model.
         :rtype: float
         """

--- a/python/interpret_community/mimic/models/lightgbm_model.py
+++ b/python/interpret_community/mimic/models/lightgbm_model.py
@@ -61,9 +61,9 @@ class _LGBMFunctionWrapper(object):
         If version is ==3.0.0, densifies the input dataset.
 
         :param X: The model evaluation examples.
-        :type X: numpy.array
+        :type X: numpy.ndarray
         :return: Prediction result.
-        :rtype: numpy.array
+        :rtype: numpy.ndarray
         """
         if issparse(X):
             X = X.toarray()
@@ -110,9 +110,9 @@ class _SparseTreeExplainer(object):
         Uses tree explainer for dense input data.
 
         :param X: The model evaluation examples.
-        :type X: numpy.array or scipy.sparse.csr_matrix
+        :type X: numpy.ndarray or scipy.sparse.csr_matrix
         :return: The feature importance values.
-        :rtype: numpy.array, scipy.sparse or list of scipy.sparse
+        :rtype: numpy.ndarray, scipy.sparse or list of scipy.sparse
         """
         if issparse(X):
             shap_values = self._lgbm.predict(X,
@@ -201,9 +201,9 @@ class LGBMExplainableModel(BaseExplainableModel):
         """Call lightgbm fit to fit the explainable model.
 
         :param dataset: The dataset to train the model on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param labels: The labels to train the model on.
-        :type labels: numpy.array
+        :type labels: numpy.ndarray
         """
         self._lgbm.fit(dataset, labels, **kwargs)
 
@@ -220,7 +220,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         """Call lightgbm predict to predict labels using the explainable model.
 
         :param dataset: The dataset to predict on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -239,7 +239,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         """Call lightgbm predict_proba to predict probabilities using the explainable model.
 
         :param dataset: The dataset to predict probabilities on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -286,7 +286,7 @@ class LGBMExplainableModel(BaseExplainableModel):
         """Use TreeExplainer to get the local feature importances from the trained explainable model.
 
         :param evaluation_examples: The evaluation examples to compute local feature importances for.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param probabilities: If output_type is probability, can specify the teacher model's
             probability for scaling the shap values.
         :type probabilities: numpy.ndarray

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -59,7 +59,7 @@ class LinearExplainer(shap.LinearExplainer):
         """Estimate the SHAP values for a set of samples.
 
         :param evaluation_examples: The evaluation examples.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: For models with a single output this returns a matrix of SHAP values
             (# samples x # features). Each row sums to the difference between the model output for that
             sample and the expected value of the model output (which is stored as expected_value
@@ -84,9 +84,9 @@ def _create_linear_explainer(model, multiclass, mean, covariance, seed):
     :param multiclass: True if this is a multiclass model.
     :type multiclass: bool
     :param mean: The mean of the dataset by columns.
-    :type mean: numpy.array
+    :type mean: numpy.ndarray
     :param covariance: The covariance matrix of the dataset.
-    :type covariance: numpy.array
+    :type covariance: numpy.ndarray
     :param seed: Random number seed.
     :type seed: int
     """
@@ -119,7 +119,7 @@ def _compute_local_shap_values(linear_explainer, evaluation_examples, classifica
     :param linear_explainer: The linear explainer or list of linear explainers in multiclass case.
     :type linear_explainer: Union[LinearExplainer, list[LinearExplainer]]
     :param evaluation_examples: The evaluation examples.
-    :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     """
     # Multiclass case
     if isinstance(linear_explainer, list):
@@ -140,7 +140,7 @@ def _compute_background_data(dataset):
     """Compute the background data for linear explainer.
 
     :param dataset: The input dataset to compute background for.
-    :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     """
     background = _summarize_data(dataset)
     if str(type(background)).endswith(".DenseData'>"):
@@ -221,9 +221,9 @@ class LinearExplainableModel(BaseExplainableModel):
         Store the mean and covariance of the background data for local explanation.
 
         :param dataset: The dataset to train the model on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param labels: The labels to train the model on.
-        :type labels: numpy.array
+        :type labels: numpy.ndarray
         """
         self._linear.fit(dataset, labels, **kwargs)
         self._background = _compute_background_data(dataset)
@@ -243,7 +243,7 @@ class LinearExplainableModel(BaseExplainableModel):
         """Call linear predict to predict labels using the explainable model.
 
         :param dataset: The dataset to predict on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -259,7 +259,7 @@ class LinearExplainableModel(BaseExplainableModel):
         """Call linear predict_proba to predict probabilities using the explainable model.
 
         :param dataset: The dataset to predict probabilities on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -288,7 +288,7 @@ class LinearExplainableModel(BaseExplainableModel):
         """Use LinearExplainer to get the local feature importances from the trained explainable model.
 
         :param evaluation_examples: The evaluation examples to compute local feature importances for.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The local explanation of feature importances.
         :rtype: Union[list, numpy.ndarray]
         """
@@ -383,9 +383,9 @@ class SGDExplainableModel(BaseExplainableModel):
         Store the mean and covariance of the background data for local explanation.
 
         :param dataset: The dataset to train the model on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param labels: The labels to train the model on.
-        :type labels: numpy.array
+        :type labels: numpy.ndarray
         """
         self._sgd.fit(dataset, labels, **kwargs)
         self._background = _compute_background_data(dataset)
@@ -405,7 +405,7 @@ class SGDExplainableModel(BaseExplainableModel):
         """Call SGD predict to predict labels using the explainable model.
 
         :param dataset: The dataset to predict on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -421,7 +421,7 @@ class SGDExplainableModel(BaseExplainableModel):
         """Call SGD predict_proba to predict probabilities using the explainable model.
 
         :param dataset: The dataset to predict probabilities on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -452,7 +452,7 @@ class SGDExplainableModel(BaseExplainableModel):
         """Use LinearExplainer to get the local feature importances from the trained explainable model.
 
         :param evaluation_examples: The evaluation examples to compute local feature importances for.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The local explanation of feature importances.
         :rtype: Union[list, numpy.ndarray]
         """

--- a/python/interpret_community/mimic/models/tree_model.py
+++ b/python/interpret_community/mimic/models/tree_model.py
@@ -82,9 +82,9 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         """Call tree fit to fit the explainable model.
 
         :param dataset: The dataset to train the model on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param labels: The labels to train the model on.
-        :type labels: numpy.array
+        :type labels: numpy.ndarray
         """
         self._tree.fit(dataset, labels, **kwargs)
 
@@ -98,7 +98,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         """Call tree predict to predict labels using the explainable model.
 
         :param dataset: The dataset to predict on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -114,7 +114,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         """Call tree predict_proba to predict probabilities using the explainable model.
 
         :param dataset: The dataset to predict probabilities on.
-        :type dataset: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type dataset: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: The predictions of the model.
         :rtype: list
         """
@@ -140,7 +140,7 @@ class DecisionTreeExplainableModel(BaseExplainableModel):
         """Use TreeExplainer to get the local feature importances from the trained explainable model.
 
         :param evaluation_examples: The evaluation examples to compute local feature importances for.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param probabilities: If output_type is probability, can specify the teacher model's
             probability for scaling the shap values.
         :type probabilities: numpy.ndarray

--- a/python/interpret_community/mimic/models/tree_model_utils.py
+++ b/python/interpret_community/mimic/models/tree_model_utils.py
@@ -18,7 +18,7 @@ def _explain_local_tree_surrogate(tree_model, evaluation_examples, tree_explaine
     :param tree_model: A tree-based model.
     :type tree_model: Tree-based model with scikit-learn predict and predict_proba API.
     :param evaluation_examples: The evaluation examples to compute local feature importances for.
-    :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param tree_explainer: Tree explainer for the tree-based model.
     :type tree_explainer: TreeExplainer
     :param shap_values_output: The type of the output from explain_local when using TreeExplainer.

--- a/python/interpret_community/permutation/permutation_importance.py
+++ b/python/interpret_community/permutation/permutation_importance.py
@@ -420,10 +420,10 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param true_labels: An array of true labels used for reference to compute the evaluation metric
             for base case and after each permutation.
-        :type true_labels: numpy.array or pandas.DataFrame
+        :type true_labels: numpy.ndarray or pandas.DataFrame
         :return: Args for explain_global.
         :rtype: dict
         """
@@ -525,10 +525,10 @@ class PFIExplainer(GlobalExplainer, BlackBoxMixin):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which to
             explain the model's output through permutation feature importance.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param true_labels: An array of true labels used for reference to compute the evaluation metric
             for base case and after each permutation.
-        :type true_labels: numpy.array or pandas.DataFrame
+        :type true_labels: numpy.ndarray or pandas.DataFrame
         :return: A model explanation object. It is guaranteed to be a GlobalExplanation.
             If the model is a classifier (has predict_proba), it will have the properties of ClassesMixin.
         :rtype: DynamicGlobalExplanation

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -107,7 +107,7 @@ def _get_summary_data(initialization_examples, nclusters, framework):
 
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param nclusters: Number of means to use for approximation. A dataset is summarized with nclusters mean
         samples weighted by the number of data points they each represent. When the number of initialization
         examples is larger than (10 x nclusters), those examples will be summarized with k-means where
@@ -117,7 +117,7 @@ def _get_summary_data(initialization_examples, nclusters, framework):
     :type framework: str
     :return: A summarized matrix of feature vector examples (# examples x # features)
         for initializing the explainer.
-    :rtype: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix or torch.autograd.Variable
+    :rtype: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix or torch.autograd.Variable
     """
     initialization_examples.compute_summary(nclusters=nclusters)
     summary = initialization_examples.dataset
@@ -138,7 +138,7 @@ class DeepExplainer(StructuredInitModelExplainer):
     :type model: PyTorch or TensorFlow model
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation. The subset can be the top-k features
         from the model summary.
@@ -203,7 +203,7 @@ class DeepExplainer(StructuredInitModelExplainer):
         :type model: PyTorch or TensorFlow model
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation. The subset can be the top-k features
             from the model summary.
@@ -289,7 +289,7 @@ class DeepExplainer(StructuredInitModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -315,7 +315,7 @@ class DeepExplainer(StructuredInitModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Args for explain_local.
         :rtype: dict
         """
@@ -385,7 +385,7 @@ class DeepExplainer(StructuredInitModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: A model explanation object. It is guaranteed to be a LocalExplanation which also has the properties
             of ExpectedValuesMixin. If the model is a classifier, it will have the properties of the ClassesMixin.
         :rtype: DynamicLocalExplanation

--- a/python/interpret_community/shap/gpu_kernel_explainer.py
+++ b/python/interpret_community/shap/gpu_kernel_explainer.py
@@ -78,7 +78,7 @@ class GPUKernelExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
         process when number of features is large and the user already knows the set of interested
@@ -209,7 +209,7 @@ class GPUKernelExplainer(BlackBoxExplainer):
         """Explain the model globally by aggregating local explanations to global.
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -43,7 +43,7 @@ class KernelExplainer(BlackBoxExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param is_function: Default is False. Set to True if passing function instead of a model.
     :type is_function: bool
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -125,7 +125,7 @@ class KernelExplainer(BlackBoxExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param is_function: Default is False. Set to True if passing function instead of a model.
         :type is_function: bool
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
@@ -242,7 +242,7 @@ class KernelExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -274,7 +274,7 @@ class KernelExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Args for explain_local.
         :rtype: dict
         """

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -37,7 +37,7 @@ class LinearExplainer(StructuredInitModelExplainer):
     :type model: (coef, intercept) or sklearn.linear_model.*
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation. The subset can be the top-k features
         from the model summary.
@@ -93,7 +93,7 @@ class LinearExplainer(StructuredInitModelExplainer):
         :type model: (coef, intercept) or sklearn.linear_model.*
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation. The subset can be the top-k features
             from the model summary.
@@ -162,7 +162,7 @@ class LinearExplainer(StructuredInitModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -202,9 +202,9 @@ class LinearExplainer(StructuredInitModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param original_evals: The original data that the user passed into explain_local.
-        :type original_evals: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type original_evals: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Args for explain_local.
         :rtype: dict
         """

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -167,7 +167,7 @@ class TreeExplainer(PureStructuredModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -214,9 +214,9 @@ class TreeExplainer(PureStructuredModelExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param original_evals: The original data that the user passed into explain_local.
-        :type original_evals: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type original_evals: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: Args for explain_local.
         :rtype: dict
         """

--- a/python/interpret_community/tabular_explainer.py
+++ b/python/interpret_community/tabular_explainer.py
@@ -41,7 +41,7 @@ class TabularExplainer(BaseExplainer):
     :type model: object
     :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
         initializing the explainer.
-    :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+    :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
     :param explain_subset: List of feature indices. If specified, only selects a subset of the
         features in the evaluation dataset for explanation, which will speed up the explanation
         process when number of features is large and the user already knows the set of interested
@@ -101,7 +101,7 @@ class TabularExplainer(BaseExplainer):
         :type model: object
         :param initialization_examples: A matrix of feature vector examples (# examples x # features) for
             initializing the explainer.
-        :type initialization_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type initialization_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param explain_subset: List of feature indices. If specified, only selects a subset of the
             features in the evaluation dataset for explanation, which will speed up the explanation
             process when number of features is large and the user already knows the set of interested
@@ -207,7 +207,7 @@ class TabularExplainer(BaseExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :param sampling_policy: Optional policy for sampling the evaluation examples.  See documentation on
             SamplingPolicy for more information.
         :type sampling_policy: interpret_community.common.policy.SamplingPolicy
@@ -233,7 +233,7 @@ class TabularExplainer(BaseExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: numpy.array or pandas.DataFrame or scipy.sparse.csr_matrix
+        :type evaluation_examples: numpy.ndarray or pandas.DataFrame or scipy.sparse.csr_matrix
         :return: A model explanation object. It is guaranteed to be a LocalExplanation. If SHAP is used for the
             explanation, it will also have the properties of the ExpectedValuesMixin. If the model does
             classification, it will have the properties of the ClassesMixin.

--- a/python/interpret_community/widget/explanation_dashboard.py
+++ b/python/interpret_community/widget/explanation_dashboard.py
@@ -25,17 +25,17 @@ class ExplanationDashboard:
     :param dataset:  A matrix of feature vector examples (# examples x # features), the same samples
         used to build the explanation. Overwrites any existing dataset on the explanation object. Must have fewer than
         10000 rows and fewer than 1000 columns.
-    :type dataset: numpy.array or list[][]
+    :type dataset: numpy.ndarray or list[][]
     :param datasetX: Alias of the dataset parameter. If dataset is passed, this will have no effect. Must have fewer
         than 10000 rows and fewer than 1000 columns.
-    :type datasetX: numpy.array or list[][]
+    :type datasetX: numpy.ndarray or list[][]
     :param true_y: The true labels for the provided dataset. Overwrites any existing dataset on the
         explanation object.
-    :type true_y: numpy.array or list[]
+    :type true_y: numpy.ndarray or list[]
     :param classes: The class names.
-    :type classes: numpy.array or list[]
+    :type classes: numpy.ndarray or list[]
     :param features: Feature names.
-    :type features: numpy.array or list[]
+    :type features: numpy.ndarray or list[]
     :param port: The port to use on locally hosted service.
     :type port: int
     :param use_cdn: Deprecated. Whether to load latest dashboard script from cdn, fall back to local script if False.


### PR DESCRIPTION
We should be using numpy.ndarray in python docs because that is the type of the numpy arrays instead of numpy.array which is the function used to create the arrays.
This PR updates the docs.