### PR TITLE
Update requirements-test.txt to pin markupsafe<2.1.0

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ flake8-blind-except==0.1.1
 flake8-breakpoint
 flake8-logging-format==0.6.0
 isort
+markupsafe<2.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,4 +9,5 @@ flake8-blind-except==0.1.1
 flake8-breakpoint
 flake8-logging-format==0.6.0
 isort
+itsdangerous==2.0.1
 markupsafe<2.1.0


### PR DESCRIPTION
It seems like the notebook tests are failing with the following exception:-

File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 171, in exec_module
    exec(co, module.__dict__)
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/dash/__init__.py", line 5, in <module>
    from .dash import Dash, no_update  # noqa: F401,E402
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/_pytest/assertion/rewrite.py", line 171, in exec_module
    exec(co, module.__dict__)
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/dash/dash.py", line 16, in <module>
    import flask
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/flask/__init__.py", line 19, in <module>
    from jinja2 import Markup, escape
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/share/miniconda/envs/test/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/share/miniconda/envs/test/lib/python3.8/site-packages/markupsafe/__init__.py)

Hence pinning markupsafe to less than 2.1.0