### PR TITLE
fix windows nightly build failures due to pywinpty dependency failing in python 3.6

### DIFF
--- a/devops/templates/all-tests-job-template.yml
+++ b/devops/templates/all-tests-job-template.yml
@@ -33,8 +33,7 @@ jobs:
       - ${{ each pyVer in parameters.pyVersions }}:
         - job:
           displayName: ${{ format('{0} {1} {2}', plat.Key , testRunType, pyVer) }}
-          ${{ if eq(plat.Key, 'Windows')}}:
-            timeoutInMinutes: 120
+          timeoutInMinutes: 120
           pool:
             vmImage: ${{ plat.value }}
 

--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -60,11 +60,6 @@ steps:
 
   - bash: |
       source activate  ${{parameters.condaEnv}} 
-      pip install --upgrade jupyter
-    displayName: Install jupyter
-
-  - bash: |
-      source activate  ${{parameters.condaEnv}} 
       pip install -r requirements-test.txt
     displayName: Install test required pip packages
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -11,3 +11,6 @@ flake8-logging-format==0.6.0
 isort
 itsdangerous==2.0.1
 markupsafe<2.1.0
+# Jupyter dependency that fails with python 3.6
+pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'
+jupyter


### PR DESCRIPTION
- fix for nightly build failures, similar to PR in responsible-ai-toolbox repo:
https://github.com/microsoft/responsible-ai-toolbox/pull/1257

failures are due to pywinpty dependency release failing in python 3.6
related issue:
https://github.com/spyder-ide/pywinpty/issues/218