### PR TITLE
fix some methods and classes missing from readthedocs documentation

### DIFF
--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.extlinks'
 ]
 # eventually we may be able to use intersphinx for these! TODO
-autodoc_mock_imports = ['shap', 'shap.common', 'interpret', 'interpret.utils']
+autodoc_mock_imports = ['interpret', 'interpret.utils', 'ml_wrappers']
 
 # enable links to objects in the other standard libraries, e.g., list and str in the Python standard library
 intersphinx_mapping = {
@@ -49,7 +49,8 @@ intersphinx_mapping = {
     'NumPy': ('https://docs.scipy.org/doc/numpy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'SciPy': ('https://docs.scipy.org/doc/scipy/reference', None),
-    'sklearn': ('https://scikit-learn.org/stable', None)
+    'sklearn': ('https://scikit-learn.org/stable', None),
+    'shap': ('https://shap.readthedocs.io/en/stable', None)
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,1 +1,2 @@
 sphinx==4.3.0
+pyyaml


### PR DESCRIPTION
Some of the methods and classes were missing in the sphinx generated documentation due to some errors in the intersphinx mapping and dependencies.  This PR resolves those documentation issues.

How I validated: I changed the latest readthedocs build to point to this branch, and then validated that the documentation was finally building.  I switched the branch back to master branch.