### PR TITLE
fix jinja2 build error with old version of flask by pinning jinja2

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,4 @@ markupsafe<2.1.0
 # Jupyter dependency that fails with python 3.6
 pywinpty==2.0.2; python_version <= '3.6' and sys_platform == 'win32'
 jupyter
+jinja2==2.11.3


### PR DESCRIPTION
Gated builds are failing recently with the error:

```
  File "/usr/share/miniconda/envs/test/lib/python3.7/site-packages/dash/dash.py", line 17, in <module>
    import flask
  File "/usr/share/miniconda/envs/test/lib/python3.7/site-packages/flask/__init__.py", line 19, in <module>
    from jinja2 import Markup, escape
ImportError: cannot import name 'Markup' from 'jinja2' (/usr/share/miniconda/envs/test/lib/python3.7/site-packages/jinja2/__init__.py)
```

This PR resolves the issue by pinning jinja2 to older version.  The alternative is to upgrade flask, but this is currently not possible due to upstream environments using older versions of flask.