### PR TITLE
fix aggregating sparse multiclass explanations to global in global-only streaming with batches mode

### DIFF
--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -12,8 +12,7 @@ from interpret_community.common.blackbox_explainer import (
     BlackBoxExplainer, add_prepare_function_and_summary_method,
     init_blackbox_decorator)
 from interpret_community.common.constants import (Defaults, ExplainParams,
-                                                  ExplainType,
-                                                  ExplanationParams, Extension,
+                                                  ExplainType, Extension,
                                                   ModelTask)
 from interpret_community.common.model_wrapper import _wrap_model
 from interpret_community.common.progress import get_tqdm
@@ -277,10 +276,10 @@ class LIMEExplainer(BlackBoxExplainer):
                   ExplainParams.BATCH_SIZE: batch_size}
 
         if self.classification:
-            kwargs[ExplanationParams.CLASSES] = self.classes
-            kwargs[ExplainType.MODEL_TASK] = ExplainType.CLASSIFICATION
+            kwargs[ExplainParams.CLASSES] = self.classes
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
         else:
-            kwargs[ExplainType.MODEL_TASK] = ExplainType.REGRESSION
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
 
         kwargs[ExplainParams.EVAL_DATA] = evaluation_examples.typed_dataset
 
@@ -330,12 +329,12 @@ class LIMEExplainer(BlackBoxExplainer):
 
         self._logger.debug('Running LIMEExplainer')
         if self.classification:
-            kwargs[ExplanationParams.CLASSES] = self.classes
-            kwargs[ExplainType.MODEL_TASK] = ExplainType.CLASSIFICATION
+            kwargs[ExplainParams.CLASSES] = self.classes
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.CLASSIFICATION
             num_classes = len(self.classes)
             labels = list(range(num_classes))
         else:
-            kwargs[ExplainType.MODEL_TASK] = ExplainType.REGRESSION
+            kwargs[ExplainParams.MODEL_TASK] = ExplainType.REGRESSION
             num_classes = 1
             labels = None
         lime_explanations = []

--- a/tests/test_mimic_explainer.py
+++ b/tests/test_mimic_explainer.py
@@ -165,6 +165,17 @@ class TestMimicExplainer(object):
             verifier.verify_explain_model_hashing(summarize_background=False,
                                                   include_evaluation_examples=False)
 
+    @pytest.mark.parametrize(("batch_size"), [None, 1, 100])
+    @pytest.mark.parametrize(("include_evaluation_examples"), [True, False])
+    def test_explain_model_hashing_without_include_local(self, verify_sparse_mimic,
+                                                         batch_size,
+                                                         include_evaluation_examples):
+        for verifier in verify_sparse_mimic:
+            verifier.verify_explain_model_hashing(summarize_background=False,
+                                                  include_evaluation_examples=include_evaluation_examples,
+                                                  include_local=False,
+                                                  batch_size=batch_size)
+
     def test_explain_model_subset_classification_dense(self, verify_mimic_regressor):
         for verifier in verify_mimic_regressor:
             verifier.verify_explain_model_subset_classification_dense(is_local=False)


### PR DESCRIPTION
Fix aggregating sparse multiclass explanations to global in global-only streaming with batches mode.

In the case that the explanations are

1.) computed on sparse multiclass data, and
2.) we set parameters to only compute the global explanation from local importance values, and
3.) we are using specifically the streaming aggregation from batches mode

(notice a lot of specific cases there), the logic currently fails as it is not designed to handle a list of sparse matrices.  The logic for this scenario is implemented in this PR and a test is added.