### PR TITLE
add more documentation to interpret-community website, including a contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Interpretability Technique|Description|Type
 |SHAP Linear Explainer| [SHAP](https://github.com/slundberg/shap)'s Linear explainer computes SHAP values for a **linear model**, optionally accounting for inter-feature correlations.|Model-specific|
 |Mimic Explainer (Global Surrogate)| Mimic explainer is based on the idea of training [global surrogate models](https://christophm.github.io/interpretable-ml-book/global.html) to mimic blackbox models. A global surrogate model is an intrinsically interpretable model that is trained to approximate the predictions of **any black box model** as accurately as possible. Data scientists can interpret the surrogate model to draw conclusions about the black box model. You can use one of the following interpretable models as your surrogate model: LightGBM (LGBMExplainableModel), Linear Regression (LinearExplainableModel), Stochastic Gradient Descent explainable model (SGDExplainableModel), and Decision Tree (DecisionTreeExplainableModel).|Model-agnostic|
 |Permutation Feature Importance Explainer (PFI)| Permutation Feature Importance is a technique used to explain classification and regression models that is inspired by [Breiman's Random Forests paper](https://www.stat.berkeley.edu/~breiman/randomforest2001.pdf) (see section 10). At a high level, the way it works is by randomly shuffling data one feature at a time for the entire dataset and calculating how much the performance metric of interest changes. The larger the change, the more important that feature is. PFI can explain the overall behavior of **any underlying model** but does not explain individual predictions. |Model-agnostic|
-
+|LIME Explainer|Local Interpretable Model-agnostic Explanations (LIME) is a local linear approximation of the model's behavior. The explainer wraps the [LIME tabular explainer](https://github.com/marcotcr/lime) with a uniform API and additional functionality.|Model-agnostic|
 
 Besides the interpretability techniques described above, Interpret-Community supports another [SHAP-based explainer](https://github.com/slundberg/shap), called `TabularExplainer`. Depending on the model, `TabularExplainer` uses one of the supported SHAP explainers:
 
@@ -120,7 +120,7 @@ For more usage information, please see [Use Interpret-Community](https://interpr
 
 ## Visualizations
 
-Install the raiwidgets package, the ExplanationDashboard has moved to the [responsible-ai-widgets](https://github.com/microsoft/responsible-ai-widgets) repo:
+Install the raiwidgets package, the ExplanationDashboard has moved to the [responsible-ai-toolbox](https://github.com/microsoft/responsible-ai-toolbox) repo:
 
 ```
 pip install raiwidgets

--- a/python/README.md
+++ b/python/README.md
@@ -32,4 +32,4 @@ Auto-generated sphinx API documentation can be found here:
 https://interpret-community.readthedocs.io/en/latest/index.html
 
 More information on the ExplanationDashboard can be found here:
-https://github.com/microsoft/responsible-ai-widgets
+https://github.com/microsoft/responsible-ai-toolbox

--- a/python/docs/_static/theme_overrides.css
+++ b/python/docs/_static/theme_overrides.css
@@ -1,0 +1,7 @@
+.wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal !important;
+}
+
+.wy-table-responsive {
+    overflow: visible !important;
+}

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -76,17 +76,17 @@ master_doc = 'index'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = [os.path.abspath(os.path.join('.', '_static'))]
 
 # Include images in the documentation
-imgpath = os.path.abspath(os.path.join(os.getcwd(), "..", "..", "img"))
+imgpath = os.path.abspath(os.path.join(os.getcwd(), '..', '..', 'img'))
 
 html_extra_path = [imgpath]
 
 
 def run_apidoc(_):
-    package_path = os.path.join("..", "interpret_community")
-    api_reference_path = os.path.join(".", "api_reference")
+    package_path = os.path.join('..', 'interpret_community')
+    api_reference_path = os.path.join('.', 'api_reference')
     argv = ["-f", "-T", "-e", "-M", "-o", api_reference_path, package_path]
 
     from sphinx.ext import apidoc
@@ -95,3 +95,4 @@ def run_apidoc(_):
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+    app.add_css_file('theme_overrides.css')

--- a/python/docs/contributing.rst
+++ b/python/docs/contributing.rst
@@ -1,0 +1,84 @@
+.. _contributing:
+
+Contributing
+============
+
+Interpret-Community is an open-source project and anyone is welcome to contribute to the project.
+
+Acceptance criteria
+-------------------
+
+All pull requests need to abide by the following criteria to be accepted:
+
+* passing pipelines on the GitHub pull request
+* approval from at least one maintainer
+* tests for added / changed functionality
+
+
+Development process
+-------------------
+
+The project can be installed locally in editable mode using the following command:
+
+   .. code-block:: bash
+
+      pip install -e .
+
+
+Testing
+-------
+
+To run tests locally, please install all of the dependencies in your python environment:
+
+   .. code-block:: bash
+
+      pip install -r requirements.txt
+      pip install -r requirements-dev.txt
+      pip install -r requirements-vis.txt
+      pip install -r requirements-test.txt
+
+The unit tests can then be run via the command:
+
+   .. code-block:: bash
+
+      pytest ./tests -m "not notebooks" -s -v
+
+Code coverage can be run locally via the command:
+
+   .. code-block:: bash
+
+      pytest ./tests -m "not notebooks" -s -v --cov='interpret_community' --cov-report=xml --cov-report=html
+
+Notebook tests can also be run via the command:
+
+   .. code-block:: bash
+
+      python -m pytest tests/ -m "notebooks" -s -v
+
+
+Linting
+-------
+
+This repository uses flake8 for linting and isort to automatically sort imports.
+
+Before running flake8, first please ensure that requirements-test.txt has been installed.
+
+Then, you can run flake8 at the root folder of the repository via:
+
+    .. code-block:: bash
+
+       flake8 --max-line-length=119 .
+
+You can use isort to identify if any imports are out of order:
+
+    .. code-block:: bash
+
+       isort . -c
+
+You can even automatically fix your code by removing the -c argument:
+
+    .. code-block:: bash
+
+       isort .
+
+After automatically sorting the imports in your code, make sure to add and commit your changes to git.

--- a/python/docs/explainers.rst
+++ b/python/docs/explainers.rst
@@ -17,6 +17,7 @@ Supported Explainers
 The following are a list of the explainers available in the community repository:
 
 .. list-table:: Explainers
+   :widths: 15 70 15
    :header-rows: 1
 
    * - Interpretability Technique
@@ -43,11 +44,15 @@ The following are a list of the explainers available in the community repository
    * - Permutation Feature Importance Explainer (PFI)
      - Permutation Feature Importance is a technique used to explain classification and regression models that is inspired by `Breiman's Random Forests paper <https://www.stat.berkeley.edu/~breiman/randomforest2001.pdf>`_ (see section 10). At a high level, the way it works is by randomly shuffling data one feature at a time for the entire dataset and calculating how much the performance metric of interest changes. The larger the change, the more important that feature is. PFI can explain the overall behavior of **any underlying model** but does not explain individual predictions.
      - Model-agnostic
+   * - LIME Explainer
+     - Local Interpretable Model-agnostic Explanations (LIME) is a local linear approximation of the model's behavior. The explainer wraps the `LIME tabular explainer <https://github.com/marcotcr/lime>`_ with a uniform API and additional functionality.
+     - Model-agnostic
 
 
 Besides the interpretability techniques described above, Interpret-Community supports another `SHAP-based explainer <https://github.com/slundberg/shap>`_, called `TabularExplainer`. Depending on the model, `TabularExplainer` uses one of the supported SHAP explainers:
 
 .. list-table:: TabularExplainer
+   :widths: 25 50
    :header-rows: 1
 
    * - Original Model

--- a/python/docs/importances.rst
+++ b/python/docs/importances.rst
@@ -37,7 +37,7 @@ Get the aggregate feature importance values.
       global_explanation.get_feature_importance_dict()
 
 
-Instance-level (local) feature importance values
+Instance-level (Local) feature importance values
 ------------------------------------------------
 
 Get the instance-level feature importance values: use the following function calls to explain an individual instance or a group of instances. Please note that PFIExplainer does not support instance-level explanations.

--- a/python/docs/index.rst
+++ b/python/docs/index.rst
@@ -44,6 +44,8 @@ The package can be installed from `pypi <https://pypi.org/project/interpret-comm
 
    visualizations
 
+   contributing
+
    api_reference/main
 
 

--- a/python/docs/usage.rst
+++ b/python/docs/usage.rst
@@ -40,7 +40,7 @@ Interpretability in training
       model = clf.fit(x_train, y_train)
 
 
-2. Call the explainer: To initialize an explainer object, you need to pass your model and some training data to the explainer's constructor. You can also optionally pass in feature names and output class names (if doing classification) which will be used to make your explanations and visualizations more informative. Here is how to instantiate an explainer object using `TabularExplainer`, `MimicExplainer`, or `PFIExplainer` locally. `TabularExplainer` calls one of the four SHAP explainers underneath (`TreeExplainer`, `DeepExplainer`, `LinearExplainer`, `KernelExplainer`, or `GPUKernelExplainer`), and automatically selects the most appropriate one for your use case. You can however, call each of its four underlying explainers directly.
+2. Call the explainer: To initialize an explainer object, you need to pass your model and some training data to the explainer's constructor. You can also optionally pass in feature names and output class names (if doing classification) which will be used to make your explanations and visualizations more informative. Here is how to instantiate an explainer object using `TabularExplainer`, `MimicExplainer`, or `PFIExplainer` locally. `TabularExplainer` calls one of the five SHAP explainers underneath (`TreeExplainer`, `DeepExplainer`, `LinearExplainer`, `KernelExplainer`, or `GPUKernelExplainer`), and automatically selects the most appropriate one for your use case. You can also call any of its four underlying explainers directly.
 
    .. code-block:: python
 

--- a/python/docs/visualizations.rst
+++ b/python/docs/visualizations.rst
@@ -3,7 +3,7 @@
 Visualizations
 ==============
 
-Install the raiwidgets package, the ExplanationDashboard has moved to the `responsible-ai-widgets <https://github.com/microsoft/responsible-ai-widgets>`_ repo:
+Install the raiwidgets package, the ExplanationDashboard has moved to the `responsible-ai-toolbox <https://github.com/microsoft/responsible-ai-toolbox>`_ repo:
 
    .. code-block:: bash
 
@@ -63,6 +63,7 @@ This view consists of two charts:
 
 
 .. list-table:: Aggregate feature importance
+   :widths: 25 50
    :header-rows: 1
 
    * - Plot
@@ -84,6 +85,7 @@ You can click on any individual data point on the scatter plot to view its local
 
 
 .. list-table:: Individual feature importance
+   :widths: 25 50
    :header-rows: 1
 
    * - Plot


### PR DESCRIPTION
More improvements to the interpret-community website, including:

- Added a contributing and code formatting guide (resolves user issue https://github.com/interpretml/interpret-community/issues/521)
- Added LIME explainer to list of supported explainers
- Fixed responsible-ai-toolbox link
- Fixed width/size of several tables in the website, so they would be more readable

Note: I temporarily moved the 'latest' build in readthedocs to this branch so it would be easier to review the correctness of the changes.