### PR TITLE
fix zero importances for very small data when using mimic explainer with lightgbm surrogate model

### DIFF
--- a/python/interpret_community/common/constants.py
+++ b/python/interpret_community/common/constants.py
@@ -181,6 +181,7 @@ class LightGBMParams(object):
     """Provide constants for LightGBM."""
 
     CATEGORICAL_FEATURE = 'categorical_feature'
+    MIN_DATA_IN_LEAF = 'min_data_in_leaf'
 
 
 class ShapValuesOutput(str, Enum):


### PR DESCRIPTION
Customers reported an issue where they were seeing all zero importance values when using mimic explainer with lightgbm surrogate model on very small data, with just 12 instances:

![image](https://user-images.githubusercontent.com/24683184/172414988-c062c948-3ae7-4d55-82bc-0ade96b9338a.png)

This PR sets the min_data_in_leaf parameter on the lightgbm surrogate model to 1 when very small data is detected in mimic explainer in order to resolve the issue by avoiding building a tree with one node and constant output due to the lack of data:

![image](https://user-images.githubusercontent.com/24683184/172415334-bdd96196-a4f3-41c0-8dc2-174ddbd0cc34.png)

Note: build is failing for this PR right now due to protobuf dependency issue, which is fixed in the separate PR:
https://github.com/interpretml/interpret-community/pull/524