### PR TITLE
fix gated build due to protobuf dependency error

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 xmlrunner
 mlflow
 tensorflow<2.5.0
+protobuf<4
 hdbscan
 lightgbm
 xgboost


### PR DESCRIPTION
Fix the gated build in interpret-community repository failing due to latest protobuf being incompatible with the version of tensorflow<2.5 used in interpret-community tests.  We pin to protobuf<4 to resolve the issue.