### PR TITLE
rename master branch to main in interpret-community

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -2,9 +2,9 @@ name: CI Python
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   ci-python:

--- a/.github/workflows/Code-Scan.yml
+++ b/.github/workflows/Code-Scan.yml
@@ -2,9 +2,9 @@ name: code scan
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   analyze:

--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -5,9 +5,9 @@ name: Python linting
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-[![Build Status](https://dev.azure.com/responsibleai/interpret-community/_apis/build/status/Nightly?branchName=master)](https://dev.azure.com/responsibleai/interpret-community/_build/latest?definitionId=41&branchName=master)
+[![Build Status](https://dev.azure.com/responsibleai/interpret-community/_apis/build/status/Nightly?branchName=main)](https://dev.azure.com/responsibleai/interpret-community/_build/latest?definitionId=41&branchName=main)
 ![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)
 ![versions](https://img.shields.io/badge/python-3.6-blue?link=https://www.python.org/downloads/release/python-360)
 ![PyPI](https://img.shields.io/pypi/v/interpret-community?color=blue?link=http://pypi.org/project/interpret-community/)

--- a/devops/Code-Coverage.yml
+++ b/devops/Code-Coverage.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Code Coverage Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 jobs:

--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -5,7 +5,7 @@ variables:
   EnvFileStem: 'environment'
 
 pr:
-- master
+- main
 
 trigger: none # No CI build
 

--- a/devops/README.md
+++ b/devops/README.md
@@ -1,6 +1,6 @@
 # Testing Strategy
 
-Currently, test pipelines are run when PRs are made to master and nightly. The nightly badge on the root README of the repo reflects the nightly unit tests.
+Currently, test pipelines are run when PRs are made to main and nightly. The nightly badge on the root README of the repo reflects the nightly unit tests.
 
 The Windows test pipelines are run against PRs and nightly and should run successfully.
 The Mac test pipeline also runs nightly, but currently has known failures. These failures are not expected to affect the user experience of Mac users.

--- a/devops/nightly.yml
+++ b/devops/nightly.yml
@@ -13,7 +13,7 @@ schedules:
   displayName: Nightly Build
   branches:
     include:
-      - master
+      - main
   always: true
 
 pool:

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -10,13 +10,13 @@ _patch = <enter new patch version here>
 
 In the notes make sure to mention all of the changes that have been introduced since the last release.  Usually you can take the main description in the PR.
 
-After the PR has been merged, checkout the master branch and get the latest code.
+After the PR has been merged, checkout the main branch and get the latest code.
 
 ## Release notes
 
 On the main page, click on releases, and select "Draft a new release".
 
-In "tag version", enter the version in the format v0.*.*, for example v0.10.0.  Keep the target as master branch.
+In "tag version", enter the version in the format v0.*.*, for example v0.10.0.  Keep the target as main branch.
 
 In release title, enter either "Patch release v0.*.*" or "Release v0.*.*".
 
@@ -63,7 +63,7 @@ password: PASSWORD_REMOVED
 
 ### Clean repo
 
-Make sure the repo is clean prior to release on the master branch, run:
+Make sure the repo is clean prior to release on the main branch, run:
 
 ```
 git clean -fdx

--- a/python/docs/notebooks.rst
+++ b/python/docs/notebooks.rst
@@ -5,11 +5,11 @@ Example Notebooks
 
 Please take a look at our example notebooks in the `notebooks/` directory:
 
-- `Blackbox interpretability for binary classification <https://github.com/interpretml/interpret-community/blob/master/notebooks/explain-binary-classification-local.ipynb>`_
-- `Blackbox interpretability for multi-class classification <https://github.com/interpretml/interpret-community/blob/master/notebooks/explain-multiclass-classification-local.ipynb>`_
-- `Blackbox interpretability for regression <https://github.com/interpretml/interpret-community/blob/master/notebooks/explain-regression-local.ipynb>`_
-- `Blackbox interpretability with simple raw feature transformations <https://github.com/interpretml/interpret-community/blob/master/notebooks/simple-feature-transformations-explain-local.ipynb>`_
-- `Blackbox interpretability with advanced raw feature transformations <https://github.com/interpretml/interpret-community/blob/master/notebooks/advanced-feature-transformations-explain-local.ipynb>`_
-- `Captum integration example <https://github.com/interpretml/interpret-community/blob/master/notebooks/captum-integration-example.ipynb>`_
-- `Explain binary classification model predictions on GPU <https://github.com/interpretml/interpret-community/blob/master/notebooks/explain-binary-classification-local-gpu.ipynb>`_
-- `Explain regression model predictions using MimicExplainer <https://github.com/interpretml/interpret-community/blob/master/notebooks/explain-regression-mimic-explainer.ipynb>`_
+- `Blackbox interpretability for binary classification <https://github.com/interpretml/interpret-community/blob/main/notebooks/explain-binary-classification-local.ipynb>`_
+- `Blackbox interpretability for multi-class classification <https://github.com/interpretml/interpret-community/blob/main/notebooks/explain-multiclass-classification-local.ipynb>`_
+- `Blackbox interpretability for regression <https://github.com/interpretml/interpret-community/blob/main/notebooks/explain-regression-local.ipynb>`_
+- `Blackbox interpretability with simple raw feature transformations <https://github.com/interpretml/interpret-community/blob/main/notebooks/simple-feature-transformations-explain-local.ipynb>`_
+- `Blackbox interpretability with advanced raw feature transformations <https://github.com/interpretml/interpret-community/blob/main/notebooks/advanced-feature-transformations-explain-local.ipynb>`_
+- `Captum integration example <https://github.com/interpretml/interpret-community/blob/main/notebooks/captum-integration-example.ipynb>`_
+- `Explain binary classification model predictions on GPU <https://github.com/interpretml/interpret-community/blob/main/notebooks/explain-binary-classification-local-gpu.ipynb>`_
+- `Explain regression model predictions using MimicExplainer <https://github.com/interpretml/interpret-community/blob/main/notebooks/explain-regression-mimic-explainer.ipynb>`_

--- a/python/docs/visualizations.rst
+++ b/python/docs/visualizations.rst
@@ -30,7 +30,7 @@ Once you load the visualization dashboard, you can investigate different aspects
    Click on "Open in a new tab" on the top left corner to get a better view of the dashboard in a new tab.
 
 
-You can further create custom cohorts (subgroups of your dataset) to explore the insights across different subgroups (e.g., women vs. men). The created cohorts can contain more than one filter (e.g., age < 30 and sex = female) and will be visible from all of the four tabs. The following sections demonstrate the visualization dashboard capabilities on a `classification model trained on employee attrition dataset <https://github.com/interpretml/interpret-community/blob/master/notebooks/simple-feature-transformations-explain-local.ipynb>`_. Besides the default cohort (including the whole dataset), there are two additional cohorts created: employees with Age <= 35 and employees with Age > 35.
+You can further create custom cohorts (subgroups of your dataset) to explore the insights across different subgroups (e.g., women vs. men). The created cohorts can contain more than one filter (e.g., age < 30 and sex = female) and will be visible from all of the four tabs. The following sections demonstrate the visualization dashboard capabilities on a `classification model trained on employee attrition dataset <https://github.com/interpretml/interpret-community/blob/main/notebooks/simple-feature-transformations-explain-local.ipynb>`_. Besides the default cohort (including the whole dataset), there are two additional cohorts created: employees with Age <= 35 and employees with Age > 35.
 
 .. image:: ./Cohorts.png
    :alt: Visualization Dashboard Cohorts


### PR DESCRIPTION
The master branch has been renamed to main in interpret-community, which is now the standard name used for github projects (due to fairness related issues).  This PR fixes related build scripts and links to point to the main branch.