### PR TITLE
release interpret-community v0.26.0

### DIFF
--- a/python/interpret_community/version.py
+++ b/python/interpret_community/version.py
@@ -1,5 +1,5 @@
 name = 'interpret_community'
 _major = '0'
-_minor = '25'
+_minor = '26'
 _patch = '0'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
## Release Notes
* Update github action for checkout, upload-artifact and setup-python from version 2 to 3 by @gaugup in https://github.com/interpretml/interpret-community/pull/515
* Add flake8-pytest-style to linting by @gaugup in https://github.com/interpretml/interpret-community/pull/512
* Improve the documentation website for interpret-community and update the main readme by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/518
* fix aggregating sparse multiclass explanations to global in global-only streaming with batches mode by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/519
* improve readme by only leaving high-level overview and move more sections to the website with more details by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/520
* add more documentation to interpret-community website, including a contributing guide by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/522
* fix gated build due to protobuf dependency error by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/524
* rename master branch to main in interpret-community by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/525
* fix zero importances for very small data when using mimic explainer with lightgbm surrogate model by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/523
* update interpret-community to ml-wrappers 0.2.0 by @imatiach-msft in https://github.com/interpretml/interpret-community/pull/527


**Full Changelog**: https://github.com/interpretml/interpret-community/compare/v0.25.0...v0.26.0