### PR TITLE
fix explanation adapter error when include_local=False and add tests

### DIFF
--- a/notebooks/captum-integration-example.ipynb
+++ b/notebooks/captum-integration-example.ipynb
@@ -224,8 +224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from interpret_community.common.model_wrapper import wrap_model\n",
-    "from interpret_community.dataset.dataset_wrapper import DatasetWrapper\n",
+    "from ml_wrappers import DatasetWrapper, wrap_model\n",
     "import pandas as pd\n",
     "wrapped_model = wrap_model(model, DatasetWrapper(input), model_task='regression')\n",
     "dataset = pd.DataFrame(np.array(input))"

--- a/python/interpret_community/_internal/raw_explain/raw_explain_utils.py
+++ b/python/interpret_community/_internal/raw_explain/raw_explain_utils.py
@@ -4,7 +4,7 @@
 
 """Contains functions useful for generating raw explanation."""
 
-from interpret_community.dataset.dataset_wrapper import DatasetWrapper
+from ml_wrappers import DatasetWrapper
 
 from .data_mapper import DataMapper
 
@@ -13,7 +13,7 @@ def transform_with_datamapper(x, datamapper):
     """Transform the input using the _datamapper field in obj.
 
     :param x: input data
-    :type x: numpy.ndarray or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
+    :type x: numpy.ndarray or pandas.DataFrame or ml_wrappers.dataset.dataset_wrapper.DatasetWrapper
     :param datamapper: datamapper object
     :type datamapper: DataMapper
     :return: transformed data
@@ -35,7 +35,7 @@ def get_datamapper_and_transformed_data(examples=None, transformations=None, all
     """Get data mapper as well as transformed examples.
 
     :param examples: input data
-    :type examples: numpy.ndarray or pandas.DataFrame or interpret_community.dataset.dataset_wrapper.DatasetWrapper
+    :type examples: numpy.ndarray or pandas.DataFrame or ml_wrappers.dataset.dataset_wrapper.DatasetWrapper
     :param transformations: transformations passed from any of DeepExplainer, KernelExplainer, MimicExplainer,
     TreeExplainer and TabularExplainer
     :type transformations: documented in constructor params of any of DeepExplainer, KernelExplainer, MimicExplainer,

--- a/python/interpret_community/common/blackbox_explainer.py
+++ b/python/interpret_community/common/blackbox_explainer.py
@@ -7,11 +7,11 @@
 from functools import wraps
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 from scipy.sparse import csr_matrix, issparse, isspmatrix_csr
 
 from .._internal.raw_explain.raw_explain_utils import \
     get_datamapper_and_transformed_data
-from ..dataset.dataset_wrapper import DatasetWrapper
 from .aggregate import init_aggregator_decorator
 from .base_explainer import BaseExplainer
 from .chained_identity import ChainedIdentity

--- a/python/interpret_community/dataset/decorator.py
+++ b/python/interpret_community/dataset/decorator.py
@@ -6,7 +6,7 @@
 
 from functools import wraps
 
-from .dataset_wrapper import DatasetWrapper
+from ml_wrappers import DatasetWrapper
 
 
 def tabular_decorator(explain_func):

--- a/python/interpret_community/explanation/serialization.py
+++ b/python/interpret_community/explanation/serialization.py
@@ -9,10 +9,10 @@ import os
 
 import numpy as np
 import pandas as pd
+from ml_wrappers import DatasetWrapper
 from scipy.sparse import csr_matrix, issparse
 
 from ..common.constants import ExplainParams, ExplainType
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..explanation import explanation as patched_explanation
 from .explanation import (ClassesMixin, FeatureImportanceExplanation,
                           GlobalExplanation, LocalExplanation,

--- a/python/interpret_community/lime/lime_explainer.py
+++ b/python/interpret_community/lime/lime_explainer.py
@@ -291,7 +291,7 @@ class LIMEExplainer(BlackBoxExplainer):
 
         :param evaluation_examples: A matrix of feature vector examples (# examples x # features) on which
             to explain the model's output.
-        :type evaluation_examples: interpret_community.dataset.dataset_wrapper.DatasetWrapper
+        :type evaluation_examples: ml_wrappers.dataset.dataset_wrapper.DatasetWrapper
         :param features: A list of feature names.
         :type features: list[str]
         :param classes: Class names as a list of strings. The order of the class names should match

--- a/python/interpret_community/mimic/mimic_explainer.py
+++ b/python/interpret_community/mimic/mimic_explainer.py
@@ -15,6 +15,7 @@ import logging
 import warnings
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 from scipy.sparse import issparse
 from sklearn.metrics import accuracy_score, r2_score
 
@@ -28,7 +29,6 @@ from ..common.constants import (Defaults, ExplainableModelType, ExplainParams,
 from ..common.exception import ScenarioNotSupportedException
 from ..common.explanation_utils import _order_imp
 from ..common.model_wrapper import _wrap_model
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
     _aggregate_global_from_local_explanation,

--- a/python/interpret_community/shap/gpu_kernel_explainer.py
+++ b/python/interpret_community/shap/gpu_kernel_explainer.py
@@ -17,6 +17,7 @@
 """Defines the GPUKernelExplainer for computing explanations on black box models or functions."""
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 
 from .._internal.raw_explain.raw_explain_utils import (
     get_datamapper_and_transformed_data, transform_with_datamapper)
@@ -30,7 +31,6 @@ from ..common.explanation_utils import (_append_shap_values_instance,
                                         _convert_single_instance_to_multi,
                                         _convert_to_list)
 from ..common.model_wrapper import _wrap_model
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,

--- a/python/interpret_community/shap/kernel_explainer.py
+++ b/python/interpret_community/shap/kernel_explainer.py
@@ -5,6 +5,7 @@
 """Defines the KernelExplainer for computing explanations on black box models or functions."""
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 
 from .._internal.raw_explain.raw_explain_utils import (
     get_datamapper_and_transformed_data, transform_with_datamapper)
@@ -19,7 +20,6 @@ from ..common.explanation_utils import (_append_shap_values_instance,
                                         _convert_to_list)
 from ..common.model_wrapper import _wrap_model
 from ..common.warnings_suppressor import shap_warnings_suppressor
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -5,6 +5,7 @@
 """Defines the LinearExplainer for returning explanations for linear models."""
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 
 from .._internal.raw_explain.raw_explain_utils import (
     get_datamapper_and_transformed_data, transform_with_datamapper)
@@ -15,7 +16,6 @@ from ..common.constants import (Attributes, Defaults, ExplainParams,
 from ..common.explanation_utils import _fix_linear_explainer_shap_values
 from ..common.structured_model_explainer import StructuredInitModelExplainer
 from ..common.warnings_suppressor import shap_warnings_suppressor
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,

--- a/python/interpret_community/shap/tree_explainer.py
+++ b/python/interpret_community/shap/tree_explainer.py
@@ -5,6 +5,7 @@
 """Defines the TreeExplainer for returning explanations for tree-based models."""
 
 import numpy as np
+from ml_wrappers import DatasetWrapper
 
 from .._internal.raw_explain.raw_explain_utils import (
     get_datamapper_and_transformed_data, transform_with_datamapper)
@@ -16,7 +17,6 @@ from ..common.explanation_utils import (_convert_to_list, _get_dense_examples,
                                         _scale_tree_shap)
 from ..common.structured_model_explainer import PureStructuredModelExplainer
 from ..common.warnings_suppressor import shap_warnings_suppressor
-from ..dataset.dataset_wrapper import DatasetWrapper
 from ..dataset.decorator import tabular_decorator
 from ..explanation.explanation import (
     _create_local_explanation, _create_raw_feats_local_explanation,

--- a/tests/explanation_utils.py
+++ b/tests/explanation_utils.py
@@ -4,11 +4,13 @@
 
 # Defines common test utilities for validating explanation objects
 
-def validate_global_classification_explanation_shape(explanation, evaluation_examples, num_classes=2):
+def validate_global_classification_explanation_shape(explanation, evaluation_examples,
+                                                     num_classes=2, include_local=True):
     assert explanation._global_importance_values.shape[0] == evaluation_examples.shape[1]
     assert explanation._per_class_values.shape[0] == num_classes
     assert explanation._per_class_values.shape[1] == evaluation_examples.shape[1]
-    validate_local_classification_explanation_shape(explanation, evaluation_examples, num_classes)
+    if include_local:
+        validate_local_classification_explanation_shape(explanation, evaluation_examples, num_classes)
 
 
 def validate_local_classification_explanation_shape(explanation, evaluation_examples, num_classes=2):
@@ -17,9 +19,11 @@ def validate_local_classification_explanation_shape(explanation, evaluation_exam
     assert explanation._local_importance_values.shape[2] == evaluation_examples.shape[1]
 
 
-def validate_global_regression_explanation_shape(explanation, evaluation_examples, num_classes=2):
+def validate_global_regression_explanation_shape(explanation, evaluation_examples,
+                                                 num_classes=2, include_local=True):
     assert explanation._global_importance_values.shape[0] == evaluation_examples.shape[1]
-    validate_local_regression_explanation_shape(explanation, evaluation_examples, num_classes)
+    if include_local:
+        validate_local_regression_explanation_shape(explanation, evaluation_examples, num_classes)
 
 
 def validate_local_regression_explanation_shape(explanation, evaluation_examples, num_classes=2):


### PR DESCRIPTION
While adding tests in explanation adapter to improve code coverage, I found an error when include_local=False which is fixed in this PR.  The issue was that we called create_local in streaming mode, but the adapter does not have this method to compute importance values on the fly, and in fact we should just be aggregating the already computed local explanation instead.
Also, this PR moves the DatasetWrapper import to use ml_wrappers directly instead.