### PR TITLE
upgrade interpret-community to new shap 0.41.0 release

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ DEPENDENCIES = [
     'scikit-learn',
     'packaging',
     'interpret-core[required]>=0.1.20, <=0.2.7',
-    'shap>=0.20.0, <=0.40.0'
+    'shap>=0.20.0, <=0.41.0'
 ]
 
 EXTRAS = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ numpy
 pandas
 scipy==1.3.3
 interpret-core[required]>=0.1.20, <=0.2.7
-shap>=0.20.0, <=0.40.0
+shap>=0.20.0, <=0.41.0
 lime>=0.2.0.0


### PR DESCRIPTION
This PR updates interpret-community to support the new latest shap 0.41.0 package, which was just released several weeks ago.