### PR TITLE
fix gated build failures due to incompatibility with new flake8 and old flake8-bugbear and old flake8-logging-format

### DIFF
--- a/python/interpret_community/tabular_explainer.py
+++ b/python/interpret_community/tabular_explainer.py
@@ -189,13 +189,15 @@ class TabularExplainer(BaseExplainer):
                         allow_all_transformations=allow_all_transformations,
                         **kwargs)
                 self._method = self.explainer._method
-                self._logger.info('Initialized valid explainer {} with args {}'.format(self.explainer, kwargs))
+                exp_init_message = 'Initialized valid explainer {} with args {}'.format(self.explainer, kwargs)
+                self._logger.info(exp_init_message)
                 is_valid = True
                 break
             except Exception as ex:
                 last_exception = ex
-                self._logger.info('Failed to initialize explainer {} due to error: {}'
-                                  .format(uninitialized_explainer, ex))
+                exp_init_failed_message = ('Failed to initialize explainer {} due to error: {}'
+                                           .format(uninitialized_explainer, ex))
+                self._logger.info(exp_init_failed_message)
         if not is_valid:
             self._logger.info(InvalidExplainerErr)
             raise ValueError(InvalidExplainerErr) from last_exception

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,10 +4,10 @@ nbformat
 papermill
 scrapbook
 flake8
-flake8-bugbear==21.11.29
+flake8-bugbear
 flake8-blind-except==0.1.1
 flake8-breakpoint
-flake8-logging-format==0.6.0
+flake8-logging-format
 flake8-pytest-style
 isort
 itsdangerous==2.0.1

--- a/tests/common_tabular_tests.py
+++ b/tests/common_tabular_tests.py
@@ -200,7 +200,7 @@ class VerifyTabularTests(object):
         assert not explanation.is_raw
         # Validate data has global info
         global_data = explanation.data(key=-1)
-        assert(InterpretData.OVERALL in global_data)
+        assert InterpretData.OVERALL in global_data
         ranked_global_values = explanation.get_ranked_global_values()
         ranked_global_names = explanation.get_ranked_global_names()
         # Note: DNNs may be too random to validate here
@@ -224,10 +224,10 @@ class VerifyTabularTests(object):
             assert explanation_local.num_classes == len(target_names)
             # Validate data has local info
             local_data = explanation_local.data(key=-1)
-            assert(InterpretData.SPECIFIC in local_data)
+            assert InterpretData.SPECIFIC in local_data
             local_data_0 = explanation_local.data(key=0)
             for key in [InterpretData.NAMES, InterpretData.SCORES, InterpretData.TYPE]:
-                assert(key in local_data_0)
+                assert key in local_data_0
 
     def verify_explain_model_local(self, expected_overall_features, expected_per_class_features=None,
                                    is_per_class=True, include_evaluation_examples=True,
@@ -390,13 +390,13 @@ class VerifyTabularTests(object):
             explanation = explainer.explain_global(x_test)
         else:
             explanation = explainer.explain_global()
-        assert(len(explanation.get_ranked_global_names()) == len(feature_names))
+        assert len(explanation.get_ranked_global_names()) == len(feature_names)
         if is_per_class:
             ranked_per_class_values = explanation.get_ranked_per_class_values()
-            assert(len(ranked_per_class_values) == len(target_names))
+            assert len(ranked_per_class_values) == len(target_names)
         explanation_local = explainer.explain_local(x_test)
         # Validate there is a local explanation per class for binary case
-        assert(np.array(explanation_local.local_importance_values).shape[0] == 2)
+        assert np.array(explanation_local.local_importance_values).shape[0] == 2
 
     def verify_explain_model_npz_linear(self, include_evaluation_examples=True, true_labels_required=False):
         # run explain model on a real sparse dataset from the field
@@ -585,7 +585,7 @@ class VerifyTabularTests(object):
             total_elems = res.shape[0] * res.shape[1]
             correct_ratio = total_in_threshold / total_elems
             # Surprisingly, they are almost identical!
-            assert(correct_ratio > 0.9)
+            assert correct_ratio > 0.9
 
     def verify_explain_model_subset_classification_sparse(self, is_local=True,
                                                           true_labels_required=False):
@@ -629,7 +629,7 @@ class VerifyTabularTests(object):
                 total_elems = res.shape[0] * res.shape[1]
                 correct_ratio = total_in_threshold / total_elems
                 # Surprisingly, they are almost identical!
-                assert(correct_ratio > 0.9)
+                assert correct_ratio > 0.9
 
     def verify_explain_model_with_sampling_regression_sparse(self, true_labels_required=False):
         # Verify that evaluation dataset can be downsampled
@@ -764,7 +764,7 @@ class VerifyTabularTests(object):
         self.validate_explanation(explanation, is_multiclass=True, is_probability=is_probability)
         # validate explanation has init_data on it in mimic explainer case (note there is none for TreeExplainer)
         if hasattr(explainer, SURROGATE_MODEL):
-            assert(explanation.init_data is not None)
+            assert explanation.init_data is not None
 
     def verify_explain_model_shap_values_binary(self, shap_values_output=ShapValuesOutput.DEFAULT,
                                                 model_type=ModelType.DEFAULT):
@@ -918,8 +918,8 @@ class VerifyTabularTests(object):
                                        ranked_global_values):
         # Verify order of features
         self.test_logger.info("length of ranked_global_values: %s", str(len(ranked_global_values)))
-        assert(len(ranked_global_values) == len(ranked_global_values))
-        assert(len(ranked_global_values) == 8)
+        assert len(ranked_global_values) == len(ranked_global_values)
+        assert len(ranked_global_values) == 8
 
     def verify_iris_overall_features(self,
                                      ranked_global_names,
@@ -933,7 +933,7 @@ class VerifyTabularTests(object):
         else:
             np.testing.assert_array_equal(ranked_global_names[0:num_overall_features_equal - 1],
                                           expected_overall_features[0:num_overall_features_equal - 1])
-        assert(len(ranked_global_values) == 4)
+        assert len(ranked_global_values) == 4
 
     def verify_iris_per_class_features(self,
                                        ranked_per_class_names,
@@ -941,8 +941,8 @@ class VerifyTabularTests(object):
                                        expected_per_class_features):
         # Verify order of features
         np.testing.assert_array_equal(ranked_per_class_names, expected_per_class_features)
-        assert(len(ranked_per_class_values) == np.array(expected_per_class_features).shape[0])
-        assert(len(ranked_per_class_values[0]) == np.array(expected_per_class_features).shape[1])
+        assert len(ranked_per_class_values) == np.array(expected_per_class_features).shape[0]
+        assert len(ranked_per_class_values[0]) == np.array(expected_per_class_features).shape[1]
 
     @property
     def iris_overall_expected_features(self):

--- a/tests/test_does_quack.py
+++ b/tests/test_does_quack.py
@@ -123,7 +123,7 @@ class _DatasetsValid(object):
 
     @property
     def eval_data(self):
-        return[[.2, .4, .01], [.3, .2, 0]]
+        return [[.2, .4, .01], [.3, .2, 0]]
 
     @property
     def eval_y_predicted(self):
@@ -610,7 +610,7 @@ class TestDoesQuack(object):
 
             @property
             def eval_data(self):
-                return[[.2, .4, .01], [.3, .2, 0]]
+                return [[.2, .4, .01], [.3, .2, 0]]
 
             @property
             def eval_y_predicted_proba(self):
@@ -625,7 +625,7 @@ class TestDoesQuack(object):
 
             @property
             def eval_data(self):
-                return[[.2, .4, .01], [.3, .2, 0]]
+                return [[.2, .4, .01], [.3, .2, 0]]
 
             @property
             def eval_y_predicted(self):

--- a/tests/test_explain_model.py
+++ b/tests/test_explain_model.py
@@ -386,7 +386,8 @@ class TestTabularExplainer(object):
         # Create tabular explainer
         exp = tabular_explainer(model, x_train, features=X.columns.values,
                                 classes=classes)
-        test_logger.info('Running explain global for {}'.format(test_name))
+        exp_glob_info_message = 'Running explain global for {}'.format(test_name)
+        test_logger.info(exp_glob_info_message)
         explanation = exp.explain_global(x_test)
         assert len(explanation.local_importance_values[0]) == len(x_test)
         assert len(explanation.local_importance_values) == len(classes)
@@ -783,7 +784,7 @@ class TestTabularExplainer(object):
         test_logger.info('Running explain global for test_explain_model_classification_with_predict_only')
         explanation = exp.explain_global(x_test)
         # Validate predicted y values are boolean
-        assert(np.all(np.isin(explanation.eval_y_predicted, [0, 1])))
+        assert np.all(np.isin(explanation.eval_y_predicted, [0, 1]))
 
     def test_tabular_explainer_get_explainers(self):
         non_gpu_explainers = _get_uninitialized_explainers(use_gpu=False)
@@ -870,7 +871,7 @@ class TestTabularExplainer(object):
                         'Age', 'Hours per week', 'Capital Loss', 'Sex', 'Occupation',
                         'Country', 'Race', 'Workclass']
         np.testing.assert_array_equal(ranked_global_names, exp_features)
-        assert(len(ranked_global_values) == len(exp_features))
+        assert len(ranked_global_values) == len(exp_features)
 
     def verify_adult_per_class_features(self, ranked_per_class_names, ranked_per_class_values):
         # Verify order of features
@@ -881,29 +882,29 @@ class TestTabularExplainer(object):
                         ['Relationship', 'Marital Status', 'Education-Num', 'Capital Gain', 'Age', 'Hours per week',
                          'Capital Loss', 'Sex', 'Occupation', 'Country', 'Race', 'Workclass']]
         np.testing.assert_array_equal(ranked_per_class_names, exp_features)
-        assert(len(ranked_per_class_values) == len(exp_features))
-        assert(len(ranked_per_class_values[0]) == len(exp_features[0]))
+        assert len(ranked_per_class_values) == len(exp_features)
+        assert len(ranked_per_class_values[0]) == len(exp_features[0])
 
     def verify_iris_overall_features(self, ranked_global_names, ranked_global_values, verify_tabular):
         # Verify order of features
         test_logger.info("length of ranked_global_values: %s", str(len(ranked_global_values)))
         exp_features = verify_tabular.iris_overall_expected_features
         np.testing.assert_array_equal(ranked_global_names, exp_features)
-        assert(len(ranked_global_values) == 4)
+        assert len(ranked_global_values) == 4
 
     def verify_iris_overall_features_no_names(self, ranked_global_names, ranked_global_values):
         # Verify order of features
         test_logger.info("length of ranked_global_values: %s", str(len(ranked_global_values)))
         exp_features = [2, 3, 0, 1]
         np.testing.assert_array_equal(ranked_global_names, exp_features)
-        assert(len(ranked_global_values) == len(exp_features))
+        assert len(ranked_global_values) == len(exp_features)
 
     def verify_iris_per_class_features(self, ranked_per_class_names, ranked_per_class_values):
         # Verify order of features
         exp_features = self.iris_per_class_expected_features
         np.testing.assert_array_equal(ranked_per_class_names, exp_features)
-        assert(len(ranked_per_class_values) == 3)
-        assert(len(ranked_per_class_values[0]) == 4)
+        assert len(ranked_per_class_values) == 3
+        assert len(ranked_per_class_values[0]) == 4
 
     def verify_iris_per_class_features_no_names(self, ranked_per_class_names, ranked_per_class_values):
         # Verify order of features
@@ -911,14 +912,14 @@ class TestTabularExplainer(object):
                         [2, 3, 0, 1],
                         [2, 3, 0, 1]]
         np.testing.assert_array_equal(ranked_per_class_names, exp_features)
-        assert(len(ranked_per_class_values) == len(exp_features))
-        assert(len(ranked_per_class_values[0]) == len(exp_features[0]))
+        assert len(ranked_per_class_values) == len(exp_features)
+        assert len(ranked_per_class_values[0]) == len(exp_features[0])
 
     def verify_housing_overall_features_rf(self, ranked_global_names, ranked_global_values):
         # Note: the order seems to differ from one machine to another, so we won't validate exact order
         test_logger.info("length of ranked_global_values: %s", str(len(ranked_global_values)))
-        assert(ranked_global_names[0] == 'MedInc')
-        assert(len(ranked_global_values) == 8)
+        assert ranked_global_names[0] == 'MedInc'
+        assert len(ranked_global_values) == 8
 
     def verify_housing_overall_features_lr(self, ranked_global_names, ranked_global_values):
         # Verify order of features
@@ -926,7 +927,7 @@ class TestTabularExplainer(object):
         exp_features = ['Latitude', 'Longitude', 'MedInc', 'AveRooms', 'HouseAge',
                         'AveBedrms', 'AveOccup', 'Population']
         np.testing.assert_array_equal(ranked_global_names, exp_features)
-        assert(len(ranked_global_values) == len(exp_features))
+        assert len(ranked_global_values) == len(exp_features)
 
     def verify_top_rows_local_features_with_and_without_top_k(self, explanation, local_features,
                                                               is_classification=False, top_rows=5):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -20,7 +20,7 @@ def test_import_tabular():
 
     import interpret_community
     importlib.reload(interpret_community)
-    assert(os.path.exists(not_existing_path))
+    assert os.path.exists(not_existing_path)
 
     del os.environ[INTERPRET_C_LOGS]
     importlib.reload(interpret_community)

--- a/tests/test_serialize_explanation.py
+++ b/tests/test_serialize_explanation.py
@@ -154,8 +154,8 @@ def _assert_sparse_data_equivalence(actual, expected, rtol=None, atol=None):
 def _assert_numpy_explanation_types(actual, expected, rtol=None, atol=None):
     # assert "_" variables equivalence
     if hasattr(actual, ExplainParams.get_private(ExplainParams.LOCAL_IMPORTANCE_VALUES)):
-        assert(isinstance(actual._local_importance_values, np.ndarray))
-        assert(isinstance(expected._local_importance_values, np.ndarray))
+        assert isinstance(actual._local_importance_values, np.ndarray)
+        assert isinstance(expected._local_importance_values, np.ndarray)
         if rtol is None:
             np.testing.assert_array_equal(actual._local_importance_values,
                                           expected._local_importance_values)
@@ -165,8 +165,8 @@ def _assert_numpy_explanation_types(actual, expected, rtol=None, atol=None):
                                        rtol=rtol,
                                        atol=atol)
     if hasattr(actual, ExplainParams.get_private(ExplainParams.EVAL_DATA)):
-        assert(isinstance(actual._eval_data, np.ndarray))
-        assert(isinstance(expected._eval_data, np.ndarray))
+        assert isinstance(actual._eval_data, np.ndarray)
+        assert isinstance(expected._eval_data, np.ndarray)
         if rtol is None:
             np.testing.assert_array_equal(actual._eval_data, expected._eval_data)
         else:

--- a/tests/test_validate_explanations.py
+++ b/tests/test_validate_explanations.py
@@ -174,16 +174,19 @@ def tabular_explainer_imp(model, x_train, x_test, allow_eval_sampling=True, use_
 
 def validate_correlation(true_order, validate_order, threshold, top_values=10):
     computed_ndcg = ndcg(true_order, validate_order, top_values)
-    test_logger.info("ndcg: " + str(computed_ndcg))
-    assert(computed_ndcg > threshold)
+    ndcg_info_message = "ndcg: " + str(computed_ndcg)
+    test_logger.info(ndcg_info_message)
+    assert computed_ndcg > threshold
 
 
 def validate_spearman_correlation(overall_imp, shap_overall_imp, threshold):
     # Calculate the spearman rank-order correlation
     rho, p_val = stats.spearmanr(overall_imp, shap_overall_imp)
     # Validate that the coefficients from the linear model are highly correlated with the results from shap
-    test_logger.info("Calculated spearman correlation coefficient rho: " + str(rho) + " and p_val: " + str(p_val))
-    assert(rho > threshold)
+    spearman_info_message = ("Calculated spearman correlation coefficient rho: {} and p_val: {}"
+                             .format(str(rho), str(p_val)))
+    test_logger.info(spearman_info_message)
+    assert rho > threshold
 
 
 def get_shap_imp_classification(explanation):


### PR DESCRIPTION
The new version of flake8 package is incompatible with the old versions of flake8-bugbear 21.11.29 and old flake8-logging-format 0.6.0.  See related issue:
https://github.com/globality-corp/flake8-logging-format/issues/35

The fix here is to remove the pin on these packages so that we always get the latest versions.  

Specifically for bugbear the error shown is:
```
(flake) PS C:\interpret-community> flake8 --max-line-length=119
Traceback (most recent call last):
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Users\ilmat\Miniconda3\envs\flake\Scripts\flake8.exe\__main__.py", line 7, in <module>
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\main\cli.py", line 22, in main
    app.run(argv)
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\main\application.py", line 336, in run
    self._run(argv)
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\main\application.py", line 325, in _run
    self.run_checks()
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\main\application.py", line 229, in run_checks
    self.file_checker_manager.run()
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\checker.py", line 252, in run
    self.run_serial()
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\checker.py", line 237, in run_serial
    checker.run_checks()
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\checker.py", line 531, in run_checks
    self.run_ast_checks()
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\flake8\checker.py", line 435, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\bugbear.py", line 61, in run
    if self.should_warn(e.message[:4]):
  File "C:\Users\ilmat\Miniconda3\envs\flake\lib\site-packages\bugbear.py", line 130, in should_warn
    if code[:i] in self.options.select:
TypeError: argument of type 'NoneType' is not iterable
```

For flake8-logging-format the error is:
```
(flake) PS C:\interpret-community> flake8 --max-line-length=119
There was a critical error during execution of Flake8:
plugin code for `flake8-logging-format[logging-format]` does not match ^[A-Z]{1,3}[0-9]{0,3}$
```