### PR TITLE
fix nightly build failure on windows when installing pip

### DIFF
--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -45,7 +45,7 @@ steps:
 
   - bash: |
       source activate ${{parameters.condaEnv}} 
-      pip install --upgrade pip --user
+      python -m pip install --upgrade pip --user
     displayName: Upgrade pip to latest for windows
     condition:  eq(variables['Agent.OS'], 'Windows_NT')
 


### PR DESCRIPTION
Nightly build is failing with error output:

```
Requirement already satisfied: pip in c:\miniconda\envs\interp_community\lib\site-packages (22.1.2)
Collecting pip
  Downloading pip-22.2.2-py3-none-any.whl (2.0 MB)
     ---------------------------------------- 2.0/2.0 MB 18.7 MB/s eta 0:00:00
ERROR: To modify pip, please run the following command:
C:\Miniconda\envs\interp_community\python.exe -m pip install --upgrade pip --user
```

This PR fixes the error by adding ```python -m``` call prior to pip install command.