### PR TITLE
temporary fix for nightly build in interpret-community

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Install visualization dependencies
       shell: bash -l {0}
       run: |
+        pip install raiwidgets
         pip install -r requirements-vis.txt
     - name: Install test dependencies
       shell: bash -l {0}

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -66,7 +66,10 @@ steps:
     condaEnv: ${{parameters.condaEnv}}
 
 - bash: |
-    source activate  ${{parameters.condaEnv}} 
+    source activate  ${{parameters.condaEnv}}
+    pip install responsibleai
+    pip install rai-core-flask==0.5.0
+    pip install raiwidgets --no-deps
     pip install -r requirements-vis.txt
   displayName: Install vis required pip packages
 

--- a/requirements-vis.txt
+++ b/requirements-vis.txt
@@ -1,4 +1,3 @@
-raiwidgets
 # used by interpret show method
 dash
 dash-cytoscape


### PR DESCRIPTION
Temporary fix by installing rai-core-flask 0.5.0 directly to bypass nightly build failures on macos due to gevent/greenlet install errors caused by old pins in rai-core-flask 0.4.0.