### PR TITLE
update interpret-community pypi release pipeline to use python 3.7

### DIFF
--- a/devops/PyPI-Release.yml
+++ b/devops/PyPI-Release.yml
@@ -19,7 +19,7 @@ parameters:
 
 variables:
   poolImage: "ubuntu-latest"
-  poolPythonVersion: 3.6
+  poolPythonVersion: 3.7
   packageArtifactName: Wheels
   versionArtifactName: Version
   versionFileName: versionInfo.txt


### PR DESCRIPTION
Update the pypi release pipeline to use python 3.7 since python 3.6 is no longer supported by default on ubuntu-latest image.  See pypi release error:

https://dev.azure.com/responsibleai/interpret-community/_build/results?buildId=15569&view=logs&j=28f19d9f-f9b2-5f7b-fd26-56c3feda2482&t=93dc4bf1-918f-5b9b-51e8-fb4711dda089

![image](https://user-images.githubusercontent.com/24683184/210447302-e41d5678-c8c5-45e4-8eda-45829332d19b.png)
