### PR TITLE
fix flake8 build error due to missing stacklevel argument for warn method

### DIFF
--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -44,7 +44,7 @@ class LinearExplainer(shap.LinearExplainer):
         if kwargs.get('feature_dependence') is not None:
             warnings.warn(("The feature_dependence parameter is deprecated and removed."
                            "Please use appropriate masker instead."),
-                          DeprecationWarning)
+                          DeprecationWarning, stacklevel=2)
         data = masker
         # Get the underlying data
         if not issubclass(type(masker), tuple):

--- a/python/interpret_community/widget/explanation_dashboard.py
+++ b/python/interpret_community/widget/explanation_dashboard.py
@@ -54,4 +54,4 @@ class ExplanationDashboard:
                  with_credentials=False, use_cdn=None):
         warnings.warn("ExplanationDashboard in interpret-community package is deprecated and removed."
                       "Please use the ExplanationDashboard from raiwidgets package instead.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -160,7 +160,7 @@ def create_cuml_svm_classifier(X, y):
         warnings.warn(
             "cuML is required to use GPU explainers. Check https://rapids.ai/start.html for \
             more information on how to install it.",
-            ImportWarning)
+            ImportWarning, stacklevel=2)
 
     clf = cuml.svm.SVC(gamma=0.001, C=100., probability=True)
     model = clf.fit(X, y)


### PR DESCRIPTION
Seeing gated builds fail due to new errors:

```
./python/interpret_community/mimic/models/linear_model.py:45:[13](https://github.com/interpretml/interpret-community/actions/runs/4264305493/jobs/7422204144#step:6:14): B028 No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
./python/interpret_community/widget/explanation_dashboard.py:55:9: B028 No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
./tests/common_utils.py:160:9: B028 No explicit stacklevel keyword argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.
```

These warnings seem to have been added to the newer releases of flake8-bugbear extension package to flake8.

This PR fixes the error by explicitly setting the stacklevel argument on the warn method call.  It seems it is recommended to set it to level 2 as it creates better warning messages by excluding the warn method itself from the printed stacktrace which can be confusing.