### PR TITLE
Update python-linting.yml to use python 3.11

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.7
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: "3.11"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Looks like python 3.7 will be deprecated in June 2023. So updating the python to 3.11 in linting workflow.