### PR TITLE
fix auto-generated API sphinx docs build for interpret-community

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -28,6 +28,12 @@ sphinx:
 python:
    install:
    - requirements: requirements-doc.txt
+   - method: pip
+     path: python
+     extra_requirements:
+        - sample
+        - mimic
+        - lime
 
 # Build PDF & ePub
 formats:


### PR DESCRIPTION
The API reference docs stopped building with the 0.29.0 release.  It looks like this is due to the removal of the requirements.txt file at the top level.  Currently the builds are failing with the error:
```
WARNING: autodoc: failed to import module 'interpret_community'; the following exception was raised:
No module named 'numpy'
```
This PR fixes the issue through the recommendation here to install the package directly in the builds in the config:
https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install
Another option may be to bring back the top-level requirements.txt file but it seems it is unnecessary.