### PR TITLE
Create requirements-linting.txt to separate linting dependencies

### DIFF
--- a/.github/workflows/python-linting.yml
+++ b/.github/workflows/python-linting.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements-test.txt
+        pip install -r requirements-linting.txt
     - name: Check sorted python imports using isort
       run: |
         isort . -c

--- a/requirements-linting.txt
+++ b/requirements-linting.txt
@@ -1,0 +1,7 @@
+flake8
+flake8-bugbear
+flake8-blind-except==0.1.1
+flake8-breakpoint
+flake8-logging-format
+flake8-pytest-style
+isort

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,13 +3,6 @@ pytest-cov
 nbformat
 papermill
 scrapbook
-flake8
-flake8-bugbear
-flake8-blind-except==0.1.1
-flake8-breakpoint
-flake8-logging-format
-flake8-pytest-style
-isort
 itsdangerous==2.0.1
 markupsafe<2.1.0
 jupyter


### PR DESCRIPTION
Looks like the linting workflow doesn't require other dependencies like jupyter, papermill etc.