### PR TITLE
fix interpret-community sphinx docs build failures by specifying html_theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.8"
+    python: "3.9"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/python/docs/conf.py
+++ b/python/docs/conf.py
@@ -69,9 +69,7 @@ master_doc = 'index'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-# Note: We will use the default theme which is nicer
-# html_theme = 'alabaster'
+html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,2 +1,3 @@
-sphinx==4.3.0
+sphinx==7.2.3
+sphinx-rtd-theme==1.3.0
 pyyaml


### PR DESCRIPTION
The interpret-community docs build started failing with errors because html_theme has become mandatory (I'm not exactly sure why, since sphinx is pinned - perhaps another package it depends on was updated?):

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/interpret-community/envs/v0.30.0/lib/python3.8/site-packages/sphinx/config.py", line 329, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/interpret-community/checkouts/v0.30.0/python/docs/conf.py", line 152, in <module>
    'html_theme': html_theme,
NameError: name 'html_theme' is not defined
```

Specifying the html_theme in this PR to resolve the sphinx doc build errors.

Also updating sphinx package to latest.

Link to passing build:
https://readthedocs.org/projects/interpret-community/builds/21721970/