### PR TITLE
update interpret-community to shap 0.44.0

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -58,7 +58,7 @@ jobs:
         pip install raiwidgets
         pip install -r requirements-vis.txt
         pip install --upgrade scikit-learn
-        pip install --upgrade "shap<=0.43.0"
+        pip install --upgrade "shap<=0.44.0"
     - name: Install test dependencies
       shell: bash -l {0}
       run: |

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -71,7 +71,7 @@ steps:
     pip install responsibleai
     pip install rai-core-flask==0.5.0
     pip install raiwidgets --no-deps
-    pip install --upgrade "shap<=0.43.0"
+    pip install --upgrade "shap<=0.44.0"
     pip install -r requirements-vis.txt
   displayName: Install vis required pip packages
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -43,7 +43,7 @@ DEPENDENCIES = [
     'scikit-learn',
     'packaging',
     'interpret-core[required]>=0.1.20, <=0.4.4',
-    'shap>=0.20.0, <=0.43.0',
+    'shap>=0.20.0, <=0.44.0',
     'raiutils~=0.4.0'
 ]
 


### PR DESCRIPTION
update interpret-community to shap 0.44.0 which was released on Dec 7, 2023:
https://pypi.org/project/shap/#history