### PR TITLE
fix gated build failures in interpret-community due to captum installation issues from conda

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -32,12 +32,12 @@ jobs:
       name: Install pytorch on non-MacOS
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch
+        conda install --yes --quiet pytorch torchvision cpuonly -c pytorch
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
       shell: bash -l {0}
       run: |
-        conda install --yes --quiet pytorch torchvision captum -c pytorch
+        conda install --yes --quiet pytorch torchvision -c pytorch
     - if: ${{ matrix.operatingSystem == 'macos-latest' }}
       name: Install lightgbm from conda on MacOS
       shell: bash -l {0}

--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -20,14 +20,14 @@ steps:
   - bash: |
       source activate ${{parameters.condaEnv}}
       conda install --yes --quiet --name  ${{parameters.condaEnv}} numpy==1.19.5 -c conda-forge
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision captum cpuonly -c pytorch
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision cpuonly -c pytorch
     displayName: Install Anaconda packages
     condition:  ne(variables['Agent.OS'], 'Darwin')
 
   - bash: |
       source activate ${{parameters.condaEnv}}
       conda install --yes --quiet --name  ${{parameters.condaEnv}} numpy==1.19.5 -c conda-forge
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision captum -c pytorch
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision -c pytorch
     displayName: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
     condition:  eq(variables['Agent.OS'], 'Darwin')
 

--- a/python/docs/overview.rst
+++ b/python/docs/overview.rst
@@ -136,7 +136,8 @@ To setup on your local machine:
     <blockquote>
         <div>
             <div class="highlight-bash notranslate">
-                <pre>conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch</pre>
+                <pre>conda install --yes --quiet pytorch torchvision cpuonly -c pytorch
+                <br/>pip install captum</pre>
             </div>
         </div>
     </blockquote>
@@ -160,7 +161,8 @@ To setup on your local machine:
     <blockquote>
         <div>
             <div class="highlight-bash notranslate">
-                <pre>conda install --yes --quiet pytorch torchvision captum cpuonly -c pytorch</pre>
+                <pre>conda install --yes --quiet pytorch torchvision cpuonly -c pytorch
+                <br/>pip install captum</pre>
             </div>
         </div>
     </blockquote>
@@ -183,7 +185,8 @@ To setup on your local machine:
     <blockquote>
         <div>
             <div class="highlight-bash notranslate">
-                <pre>conda install --yes --quiet pytorch torchvision captum -c pytorch</pre>
+                <pre>conda install --yes --quiet pytorch torchvision -c pytorch
+                <br/>pip install captum</pre>
             </div>
         </div>
     </blockquote>
@@ -216,13 +219,21 @@ To setup on your local machine:
     <summary><strong><em>4. Set up and run Jupyter Notebook server </em></strong></summary>
 
     Install and run Jupyter Notebook
+    if needed:
     <blockquote>
         <div>
             <div class="highlight-bash notranslate">
-                <pre>if needed:
-                </br>pip install jupyter
-                <br/>then:
-                <br/>jupyter notebook</pre>
+                <pre>
+                </br>pip install jupyter</pre>
+            </div>
+        </div>
+    </blockquote>
+    then:
+    <blockquote>
+        <div>
+            <div class="highlight-bash notranslate">
+                <pre>
+                </br>jupyter notebook</pre>
             </div>
         </div>
     </blockquote>

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ itsdangerous==2.0.1
 markupsafe<2.1.0
 jupyter
 jinja2==2.11.3
+captum


### PR DESCRIPTION
fix gated build failures in interpret-community due to captum installation issues from conda

Getting errors in gated builds:

```
ImportError while importing test module '/Users/runner/work/1/s/tests/test_explanation_adapter.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/miniconda/envs/interp_community/lib/python3.7/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_explanation_adapter.py:9: in <module>
    from captum.attr import IntegratedGradients
E   ModuleNotFoundError: No module named 'captum'
```

We were seeing similar errors in the https://github.com/microsoft/responsible-ai-toolbox repository and a similar fix was applied there to move captum to pip install after a new version of pytorch was released:
https://github.com/microsoft/responsible-ai-toolbox/pull/2435