### PR TITLE
update interpret to 0.5.0, ml-wrappers to 0.5.4

### DIFF
--- a/devops/PR-Gate.yml
+++ b/devops/PR-Gate.yml
@@ -18,7 +18,7 @@ jobs:
   parameters:
     platforms:  { MacOS: macos-latest }
     testRunTypes: ['Notebooks']
-    pyVersions: [3.7]
+    pyVersions: [3.8]
     installationType: PipLocal
     envArtifactStem: $(EnvArtifactStem)
     envFileStem: $(EnvFileStem)

--- a/python/setup.py
+++ b/python/setup.py
@@ -39,10 +39,11 @@ DEPENDENCIES = [
     'numpy',
     'pandas<2.0.0',
     'scipy',
-    'ml-wrappers~=0.5.2',
+    'ml-wrappers~=0.5.4',
     'scikit-learn',
     'packaging',
-    'interpret-core[required]>=0.1.20, <=0.4.4',
+    'interpret-core>=0.1.20, <0.5.0; python_version <= "3.7"',
+    'interpret-core>=0.1.20, <=0.5.0; python_version >= "3.8"',
     'shap>=0.20.0, <=0.44.0',
     'raiutils~=0.4.0'
 ]


### PR DESCRIPTION
update interpret-community package to interpret 0.5.0, ml-wrappers 0.5.4

Update: it looks like interpret-core has removed the "required" extra with 0.5.0, see:
https://github.com/interpretml/interpret/commit/ee37ca1902d034c2bc5e5aed113c8d46a300d59a#diff-7a456cafef94c199eaa08821e95e9c72394da4be21fcfc965ec8b29170c9c2e8

Hence, removing it from this PR now - otherwise the install process gives an error.