### PR TITLE
update interpret-community to ml-wrappers 0.6.0

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -66,6 +66,7 @@ jobs:
       shell: bash -l {0}
       run: |
         pip install -r requirements-test.txt
+        pip install --upgrade "pandas>2.0"
     - name: Test with pytest
       shell: bash -l {0}
       run: |

--- a/devops/templates/create-env-step-template.yml
+++ b/devops/templates/create-env-step-template.yml
@@ -19,15 +19,13 @@ steps:
 
   - bash: |
       source activate ${{parameters.condaEnv}}
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} "numpy<1.24.0" -c conda-forge
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision cpuonly -c pytorch
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision cpuonly -c pytorch -c conda-forge --strict-channel-priority
     displayName: Install Anaconda packages
     condition:  ne(variables['Agent.OS'], 'Darwin')
 
   - bash: |
       source activate ${{parameters.condaEnv}}
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} "numpy<1.24.0" -c conda-forge
-      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision -c pytorch
+      conda install --yes --quiet --name  ${{parameters.condaEnv}} pytorch torchvision -c pytorch -c conda-forge --strict-channel-priority
     displayName: Install Anaconda packages on MacOS, which should not include cpuonly according to official docs
     condition:  eq(variables['Agent.OS'], 'Darwin')
 

--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -300,7 +300,11 @@ def _scale_single_shap_matrix(shap_values, expectation, prediction):
     mimic_prediction = np.sum(shap_values, axis=1)
     error = prediction - mimic_prediction - expectation
     absolute_error = np.abs(error)
+    if not isinstance(absolute_error, np.ndarray):
+        absolute_error = np.array(absolute_error)
     error_sign = np.sign(error)
+    if not isinstance(error_sign, np.ndarray):
+        error_sign = np.array(error_sign)
     absolute_shap_vector = np.abs(shap_values)
     absolute_shap_magnitude = np.sum(absolute_shap_vector, axis=1)
     # We divide by one, when we know the numerator is 0

--- a/python/setup.py
+++ b/python/setup.py
@@ -37,11 +37,10 @@ DEPENDENCIES = [
     'numpy',
     'pandas',
     'scipy',
-    'ml-wrappers~=0.5.4',
+    'ml-wrappers~=0.6.0',
     'scikit-learn',
     'packaging',
-    'interpret-core>=0.1.20, <0.5.0; python_version <= "3.7"',
-    'interpret-core>=0.1.20, <=0.5.0; python_version >= "3.8"',
+    'interpret-core>=0.1.20, <=0.6.9',
     'shap>=0.20.0, <=0.46.0',
     'raiutils~=0.4.0'
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 xmlrunner
 mlflow
-tensorflow<2.14.0
+tensorflow
 hdbscan
 lightgbm
 xgboost<2.1.0

--- a/tests/common_utils.py
+++ b/tests/common_utils.py
@@ -247,7 +247,7 @@ def create_keras_regressor(X, y):
     epochs = 12
     model = _common_model_generator(X.shape[1])
     model.add(Activation('linear'))
-    model.compile(loss=keras.losses.mean_squared_error,
+    model.compile(loss=keras.losses.MeanSquaredError,
                   optimizer=keras.optimizers.Adadelta(),
                   metrics=['accuracy'])
     model.fit(X, y,


### PR DESCRIPTION
update interpret-community to ml-wrappers 0.6.0
As part of this, support pandas>2.0 and update to latest interpret-core
Copilot summary:
This pull request includes several updates to dependencies and improvements to error handling and package installation processes. The most important changes are summarized below:

### Dependency Updates:
* Updated `ml-wrappers` to version `0.6.0` and `interpret-core` to version `0.6.9` in `python/setup.py`.
* Removed version constraint for `tensorflow` in `requirements-dev.txt`.

### Package Installation:
* Modified the Conda package installation commands in `devops/templates/create-env-step-template.yml` to enforce strict channel priority and ensure consistent package versions.

### Error Handling:
* Added checks to convert `absolute_error` and `error_sign` to numpy arrays if they are not already in `_scale_single_shap_matrix` function in `python/interpret_community/common/explanation_utils.py`.

### Testing:
* Updated the `create_keras_regressor` function in `tests/common_utils.py` to use `keras.losses.MeanSquaredError` instead of `keras.losses.mean_squared_error`.

### CI Configuration:
* Upgraded `pandas` to a version greater than `2.0` in the CI configuration file `.github/workflows/CI-python.yml`.