### PR TITLE
update interpret-community to python 3.9 by default

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         packageDirectory: ["interpret_community"]
         operatingSystem: [ubuntu-latest]
-        pythonVersion: [3.7, 3.8, 3.9]
+        pythonVersion: [3.9]
 
     runs-on: ${{ matrix.operatingSystem }}
 
@@ -71,14 +71,14 @@ jobs:
       run: |
         pytest ./tests -m "not notebooks" -s -v --cov=${{ matrix.packageDirectory }} --cov-report=xml --cov-report=html
 
-    - if: ${{ matrix.pythonVersion == '3.8' }}
+    - if: ${{ matrix.pythonVersion == '3.9' }}
       name: Upload code coverage results
       uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.packageDirectory }}-code-coverage-results
         path: htmlcov
 
-    - if: ${{ matrix.pythonVersion == '3.8' }}
+    - if: ${{ matrix.pythonVersion == '3.9' }}
       name: Upload to codecov
       id: codecovupload1
       uses: codecov/codecov-action@v3
@@ -93,7 +93,7 @@ jobs:
         path_to_write_report: ./coverage/codecov_report.txt
         verbose: true
 
-    - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.8') }}
+    - if: ${{ (steps.codecovupload1.outcome == 'failure') && (matrix.pythonVersion == '3.9') }}
       name: Retry upload to codecov
       id: codecovupload2
       uses: codecov/codecov-action@v3
@@ -108,7 +108,7 @@ jobs:
         path_to_write_report: ./coverage/codecov_report.txt
         verbose: true
 
-    - if: ${{ matrix.pythonVersion == '3.8' }}
+    - if: ${{ matrix.pythonVersion == '3.9' }}
       name: Set codecov status
       shell: bash
       run: |

--- a/.github/workflows/release-interpret-community.yml
+++ b/.github/workflows/release-interpret-community.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install pytorch on non-MacOS
         shell: bash -l {0}

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,8 +26,6 @@ CLASSIFIERS = [
     'Intended Audience :: Science/Research',
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Topic :: Scientific/Engineering :: Artificial Intelligence',
     'Operating System :: Microsoft :: Windows',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ mlflow
 tensorflow<2.14.0
 hdbscan
 lightgbm
-xgboost
+xgboost<2.1.0
 sklearn_pandas
 lime>=0.2.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,8 +3,5 @@ pytest-cov
 nbformat
 papermill
 scrapbook
-itsdangerous==2.0.1
-markupsafe<2.1.0
 jupyter
-jinja2==2.11.3
 captum


### PR DESCRIPTION
update interpret-community to python 3.9 by default and fix some test failures in gated builds

Copilot summary:
This pull request focuses on updating the supported Python versions in the CI workflows and the package metadata. The most important changes include removing support for Python 3.7 and 3.8 and standardizing on Python 3.9.

Updates to CI workflows:

* [`.github/workflows/CI-python.yml`](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L17-R17): Removed Python 3.7 and 3.8 from the `matrix` configuration, now only testing with Python 3.9. Updated conditions for uploading code coverage results, retrying uploads, and setting codecov status to use Python 3.9 instead of 3.8. [[1]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L17-R17) [[2]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L74-R81) [[3]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L96-R96) [[4]](diffhunk://#diff-2b75812bc12c9a72b073df40c11ceda4af97cc64083831530ca88c683447b387L111-R111)
* [`.github/workflows/release-interpret-community.yml`](diffhunk://#diff-3048c6adcbcfbb938d7917aeeaa3da8a769f9d31975bae71c454ae4ac1e6b806L28-R28): Changed the `python-version` for the conda setup from 3.8 to 3.9.

Updates to package metadata:

* [`python/setup.py`](diffhunk://#diff-eb8b42d9346d0a5d371facf21a8bfa2d16fb49e213ae7c21f03863accebe0fcfL29-L30): Removed classifiers for Python 3.7 and 3.8, leaving only Python 3.9.