### PR TITLE
update interpret-community to shap 0.46.0

### DIFF
--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         pip install raiwidgets
         pip install -r requirements-vis.txt
-        pip install --upgrade "shap<=0.44.0"
+        pip install --upgrade "shap<=0.46.0"
     - if: ${{ matrix.pythonVersion == '3.9' }}
       name: Install scikit-learn to work around raiwidgets dependency
       shell: bash -l {0}

--- a/.github/workflows/release-interpret-community.yml
+++ b/.github/workflows/release-interpret-community.yml
@@ -50,7 +50,7 @@ jobs:
           pip install raiwidgets
           pip install -r requirements-vis.txt
           pip install --upgrade scikit-learn
-          pip install --upgrade "shap<=0.44.0"
+          pip install --upgrade "shap<=0.46.0"
 
       - name: Install test dependencies
         shell: bash -l {0}

--- a/devops/templates/test-run-step-template.yml
+++ b/devops/templates/test-run-step-template.yml
@@ -71,7 +71,7 @@ steps:
     pip install responsibleai
     pip install rai-core-flask==0.7.6
     pip install raiwidgets --no-deps
-    pip install --upgrade "shap<=0.44.0"
+    pip install --upgrade "shap<=0.46.0"
     pip install -r requirements-vis.txt
   displayName: Install vis required pip packages
 

--- a/python/interpret_community/common/explanation_utils.py
+++ b/python/interpret_community/common/explanation_utils.py
@@ -28,6 +28,32 @@ _RANKING = 'ranking'
 _FEATURES = 'features'
 
 
+def reformat_importance_values(local_importance_values, convert_to_list=False):
+    """Reformat to match the expected values from different shap versions.
+
+    With shap 0.45.0, the local_importance_values format changed
+    from (# classes x # examples x # features)
+    to (# examples x # classes x # features).
+
+    :param local_importance_values: The feature importance values.
+    :type local_importance_values: numpy.ndarray or scipy.sparse.csr_matrix or list[scipy.sparse.csr_matrix]
+    :param convert_to_list: Whether to convert the output to a list.
+    :type convert_to_list: bool
+    :return: The reformatted feature importance values.
+    :rtype: numpy.ndarray or list
+    """
+    if isinstance(local_importance_values, np.ndarray) and local_importance_values.ndim == 3:
+        # Note: this is logic for shap>=0.46.0, which outputs 3d array
+        # with shape (# examples x # features x # classes)
+        # Move first dimension to last
+        local_importance_values = np.moveaxis(local_importance_values, 2, 0)
+        if convert_to_list:
+            local_importance_values = list(local_importance_values)
+    elif not convert_to_list:
+        local_importance_values = np.array(local_importance_values)
+    return local_importance_values
+
+
 def _summarize_data(X, k=10, use_gpu=False, to_round_values=True):
     """Summarize a dataset.
 

--- a/python/interpret_community/mimic/models/explainable_model.py
+++ b/python/interpret_community/mimic/models/explainable_model.py
@@ -82,7 +82,7 @@ class BaseExplainableModel(ABC, ChainedIdentity):
         pass
 
     def __getstate__(self):
-        """Influence how SGDExplainableModel is pickled.
+        """Influence how BaseExplainableModel is pickled.
 
         Removes logger which is not serializable.
 
@@ -94,7 +94,7 @@ class BaseExplainableModel(ABC, ChainedIdentity):
         return odict
 
     def __setstate__(self, state):
-        """Influence how SGDExplainableModel is unpickled.
+        """Influence how BaseExplainableModel is unpickled.
 
         Re-adds logger which is not serializable.
 

--- a/python/interpret_community/mimic/models/linear_model.py
+++ b/python/interpret_community/mimic/models/linear_model.py
@@ -12,7 +12,8 @@ from sklearn.linear_model import (Lasso, LinearRegression, LogisticRegression,
                                   SGDClassifier, SGDRegressor)
 
 from ...common.constants import ExplainableModelType, Extension
-from ...common.explanation_utils import _summarize_data
+from ...common.explanation_utils import (_summarize_data,
+                                         reformat_importance_values)
 from ...common.warnings_suppressor import shap_warnings_suppressor
 from .explainable_model import (BaseExplainableModel, _clean_doc,
                                 _get_initializer_args)
@@ -79,7 +80,9 @@ class LinearExplainer(shap.LinearExplainer):
             mean_multiplier = csr_matrix(np.ones((evaluation_examples.shape[0], 1)))
             return (evaluation_examples - mean_multiplier * self._background).multiply(self.coef[0]).tocsr()
         else:
-            return super(LinearExplainer, self).shap_values(evaluation_examples)
+            shap_values = super(LinearExplainer, self).shap_values(evaluation_examples)
+            shap_values = reformat_importance_values(shap_values, convert_to_list=True)
+            return shap_values
 
 
 def _create_linear_explainer(model, multiclass, mean, covariance, seed):

--- a/python/interpret_community/mimic/models/tree_model_utils.py
+++ b/python/interpret_community/mimic/models/tree_model_utils.py
@@ -7,7 +7,8 @@
 from scipy.special import expit
 
 from ...common.constants import ShapValuesOutput
-from ...common.explanation_utils import _scale_tree_shap
+from ...common.explanation_utils import (_scale_tree_shap,
+                                         reformat_importance_values)
 
 
 def _explain_local_tree_surrogate(tree_model, evaluation_examples, tree_explainer,
@@ -44,6 +45,7 @@ def _explain_local_tree_surrogate(tree_model, evaluation_examples, tree_explaine
     # In binary case, we are using regressor on logit.  In multiclass case, shap TreeExplainer
     # outputs the margin instead of probabilities.
     shap_values = tree_explainer.shap_values(evaluation_examples)
+    shap_values = reformat_importance_values(shap_values, convert_to_list=True)
     is_probability = shap_values_output == ShapValuesOutput.PROBABILITY
     is_teacher_probability = shap_values_output == ShapValuesOutput.TEACHER_PROBABILITY
     if is_probability or is_teacher_probability:

--- a/python/interpret_community/shap/deep_explainer.py
+++ b/python/interpret_community/shap/deep_explainer.py
@@ -17,7 +17,8 @@ from interpret_community.common.constants import (Attributes, Defaults,
 
 from ..common.aggregate import (add_explain_global_method,
                                 init_aggregator_decorator)
-from ..common.explanation_utils import _convert_to_list, _get_dense_examples
+from ..common.explanation_utils import (_convert_to_list, _get_dense_examples,
+                                        reformat_importance_values)
 from ..common.structured_model_explainer import StructuredInitModelExplainer
 from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.decorator import init_tabular_decorator, tabular_decorator
@@ -352,6 +353,7 @@ class DeepExplainer(StructuredInitModelExplainer):
             dense_examples = torch.Tensor(dense_examples)
         shap_values = self.explainer.shap_values(
             dense_examples, check_additivity=self._check_additivity)
+        shap_values = reformat_importance_values(shap_values, convert_to_list=True)
         # use model task to update structure of shap values
         single_output = isinstance(shap_values, list) and len(shap_values) == 1
         if single_output:

--- a/python/interpret_community/shap/linear_explainer.py
+++ b/python/interpret_community/shap/linear_explainer.py
@@ -13,7 +13,8 @@ from ..common.aggregate import (add_explain_global_method,
                                 init_aggregator_decorator)
 from ..common.constants import (Attributes, Defaults, ExplainParams,
                                 ExplainType, Extension, SKLearn)
-from ..common.explanation_utils import _fix_linear_explainer_shap_values
+from ..common.explanation_utils import (_fix_linear_explainer_shap_values,
+                                        reformat_importance_values)
 from ..common.structured_model_explainer import StructuredInitModelExplainer
 from ..common.warnings_suppressor import shap_warnings_suppressor
 from ..dataset.decorator import tabular_decorator
@@ -216,6 +217,7 @@ class LinearExplainer(StructuredInitModelExplainer):
         evaluation_examples = evaluation_examples.dataset
 
         shap_values = self.explainer.shap_values(evaluation_examples)
+        shap_values = reformat_importance_values(shap_values, convert_to_list=True)
         # Temporary fix for a bug in shap for regression models
         shap_values = _fix_linear_explainer_shap_values(self.model, shap_values)
         expected_values = None

--- a/python/setup.py
+++ b/python/setup.py
@@ -42,7 +42,7 @@ DEPENDENCIES = [
     'packaging',
     'interpret-core>=0.1.20, <0.5.0; python_version <= "3.7"',
     'interpret-core>=0.1.20, <=0.5.0; python_version >= "3.8"',
-    'shap>=0.20.0, <=0.44.0',
+    'shap>=0.20.0, <=0.46.0',
     'raiutils~=0.4.0'
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,8 @@ def get_mimic_explainers(classifier=True):
     else:
         explainable_models_args = [{}, {}, {}, {}]
     for explainer, explainable_model_args in zip(explainers, explainable_models_args):
+        if explainer == LGBMExplainableModel:
+            explainable_model_args['verbosity'] = -1
         generated_create_explainer = generate_create_method(explainer, explainable_model_args=explainable_model_args)
         verify_mimic.append(VerifyTabularTests(test_logger, generated_create_explainer, specify_policy=False))
     return verify_mimic

--- a/tests/test_validate_explanations.py
+++ b/tests/test_validate_explanations.py
@@ -28,6 +28,8 @@ from common_utils import (create_cancer_data, create_cuml_svm_classifier,
                           create_sklearn_random_forest_regressor)
 from constants import owner_email_tools_and_ux
 from interpret_community.common.constants import ExplainParams
+from interpret_community.common.explanation_utils import \
+    reformat_importance_values
 from interpret_community.common.metrics import ndcg
 from interpret_community.common.policy import SamplingPolicy
 from interpret_community.tabular_explainer import TabularExplainer
@@ -190,6 +192,7 @@ def validate_spearman_correlation(overall_imp, shap_overall_imp, threshold):
 
 
 def get_shap_imp_classification(explanation):
+    explanation = reformat_importance_values(explanation, convert_to_list=True)
     global_importance_values = np.mean(np.mean(np.absolute(explanation), axis=1), axis=0)
     return global_importance_values.argsort()[..., ::-1]
 


### PR DESCRIPTION
update interpret-community to shap 0.46.0

This includes fixes for major breaking change https://github.com/shap/shap/pull/3318 which broke all of the explainers and changed the dimensions/format from list of 2d np.ndarray
```
(# classes x # examples x # features)
```
to 3d np.ndarray
```
(# examples x # features x # classes)
```